### PR TITLE
Compute ram_K dynamically from trace, matching Jolt

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,13 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(lib);
 
+    // Export zolt module for dependency consumption
+    _ = b.addModule("zolt", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     // Main executable (for testing/demo)
     const exe = b.addExecutable(.{
         .name = "zolt",

--- a/src/zkvm/jolt_prover.zig
+++ b/src/zkvm/jolt_prover.zig
@@ -2739,13 +2739,18 @@ pub fn JoltProver(comptime F: type) type {
                 // Stage 2 aligns all RAM sumchecks to share the same r_address.
                 // The RamRaClaimReduction (Stage 5) is cycle-only; the address comes from Stage 2.
                 {
-                    // stage2_result.r_address_raf is BIG_ENDIAN, length = ram_d * log_k_chunk
-                    // Split into ram_d chunks of log_k_chunk (matching Stage 6's ram_ra_addr_chunks)
+                    // Pad r_address_raf with leading zeros to make length a multiple of
+                    // log_k_chunk (matching Jolt's compute_r_address_chunks)
+                    const raf_len = stage2_result.r_address_raf.len;
+                    const padded_len = ((raf_len + s6_log_k_chunk - 1) / s6_log_k_chunk) * s6_log_k_chunk;
+                    const pad_count = padded_len - raf_len;
+
                     for (0..s6_ram_d) |i| {
                         var chunk = try self.allocator.alloc(F, s6_log_k_chunk);
                         const chunk_start = i * s6_log_k_chunk;
                         for (0..s6_log_k_chunk) |ci| {
-                            chunk[ci] = stage2_result.r_address_raf[chunk_start + ci];
+                            const src_idx = chunk_start + ci;
+                            chunk[ci] = if (src_idx < pad_count) F.zero() else stage2_result.r_address_raf[src_idx - pad_count];
                         }
                         r_addr_virt[s6_instruction_d + s6_bytecode_d + i] = chunk;
                     }

--- a/src/zkvm/mod.zig
+++ b/src/zkvm/mod.zig
@@ -377,7 +377,34 @@ pub fn JoltProver(comptime F: type) type {
             // Compute log_t and log_k directly from trace (already padded to power of 2)
             const trace_length = emulator.trace.steps.items.len;
             const log_t: u8 = @intCast(std.math.log2_int(usize, trace_length));
-            const log_k: u8 = 16; // log2 of RAM address space size (2^16)
+            // Compute ram_K from trace like Jolt: max remapped address across all
+            // trace steps, combined with bytecode region, rounded to next power of 2.
+            const log_k: u8 = blk: {
+                const ml = emulator.device.memory_layout;
+
+                // 1. Find max remapped address from trace
+                var max_remapped: u64 = 0;
+                for (emulator.trace.steps.items) |step| {
+                    if (step.memory_addr) |addr| {
+                        if (ml.remapAddress(addr)) |raddr| {
+                            if (raddr > max_remapped) max_remapped = raddr;
+                        }
+                    }
+                }
+
+                // 2. Account for bytecode region (like Jolt's min_bytecode_address + bytecode_words.len + 1)
+                const min_word = base_address / 8;
+                const max_word = (base_address + program_bytecode.len - 1 + 7) / 8;
+                const num_bytecode_words = max_word - min_word + 1;
+                const min_bytecode_address = min_word * 8;
+                if (ml.remapAddress(min_bytecode_address)) |raddr| {
+                    const bytecode_end = raddr + num_bytecode_words + 1;
+                    if (bytecode_end > max_remapped) max_remapped = bytecode_end;
+                }
+
+                const ram_k = std.math.ceilPowerOfTwo(u64, max_remapped) catch (1 << 16);
+                break :blk @intCast(std.math.log2_int(u64, ram_k));
+            };
 
             // Create JoltDevice for Fiat-Shamir preamble
             // CRITICAL: Use actual emulator outputs and panic state for Fiat-Shamir transcript

--- a/src/zkvm/spartan/stage6_prover.zig
+++ b/src/zkvm/spartan/stage6_prover.zig
@@ -4056,7 +4056,7 @@ pub fn Stage6BatchedProver(comptime F: type) type {
             // ====================================================================
 
             const LOOKUPS_LOG_K: usize = 128;
-            const ram_log_k: usize = std.math.log2_int(usize, @as(usize, 1) << @intCast(ram_d * log_k_chunk));
+            const ram_log_k: usize = ram_r_address_stage2_be.len;
 
             // RamRaVirtual: r_cycle from Stage 5 RamRaClaimReduction, r_address from Stage 2
             // RamRaClaimReduction is cycle-only (log_T rounds), NOT address+cycle.
@@ -4075,14 +4075,27 @@ pub fn Stage6BatchedProver(comptime F: type) type {
             }
 
             // r_address for RamRa: from Stage 2 aligned RAM address (already BIG_ENDIAN)
-            const ram_ra_r_address_be = ram_r_address_stage2_be;
+            // Pad with leading zeros to make length a multiple of log_k_chunk (matching Jolt's compute_r_address_chunks)
+            const padded_ram_len = ((ram_log_k + log_k_chunk - 1) / log_k_chunk) * log_k_chunk;
+            var ram_ra_r_address_be: []F = undefined;
+            var ram_ra_r_address_allocated = false;
+            if (padded_ram_len != ram_log_k) {
+                ram_ra_r_address_be = try self.allocator.alloc(F, padded_ram_len);
+                ram_ra_r_address_allocated = true;
+                const pad_count = padded_ram_len - ram_log_k;
+                @memset(ram_ra_r_address_be[0..pad_count], F.zero());
+                @memcpy(ram_ra_r_address_be[pad_count..], ram_r_address_stage2_be);
+            } else {
+                ram_ra_r_address_be = @constCast(ram_r_address_stage2_be);
+            }
+            defer if (ram_ra_r_address_allocated) self.allocator.free(ram_ra_r_address_be);
 
             // Split r_address into chunks (BIG_ENDIAN, chunk[0] = MSB)
             var ram_ra_addr_chunks = try self.allocator.alloc([]const F, ram_d);
             defer self.allocator.free(ram_ra_addr_chunks);
             for (0..ram_d) |i| {
                 const chunk_start = i * log_k_chunk;
-                const chunk_end = @min(chunk_start + log_k_chunk, ram_log_k);
+                const chunk_end = chunk_start + log_k_chunk;
                 ram_ra_addr_chunks[i] = ram_ra_r_address_be[chunk_start..chunk_end];
             }
 


### PR DESCRIPTION
Previously log_k was hardcoded to 16 (K=65536), causing stage5 prover out-of-bounds panics for programs with >35 cycles (e.g., bytes-sum at 133 cycles).

Now ram_K is computed from the actual trace like Jolt's prover.rs: max remapped address across all trace steps, combined with the bytecode region, rounded to next power of 2.

Also fix address chunk splitting in stage6 and jolt_prover to pad r_address with leading zeros when log_k isn't a multiple of log_k_chunk, matching Jolt's compute_r_address_chunks.