### PR TITLE
perf: gate all Stage 3 and Stage 5 debug code behind comptime flag

### DIFF
--- a/src/zkvm/spartan/stage3_prover.zig
+++ b/src/zkvm/spartan/stage3_prover.zig
@@ -132,17 +132,19 @@ pub fn Stage3Prover(comptime F: type) type {
             const trace_len = cycle_witnesses.len;
 
             // Debug: Check what witnesses we received
-            dbg("[STAGE3] generateStage3Proof: cycle_witnesses.len = {}\n", .{cycle_witnesses.len});
-            if (cycle_witnesses.len > 0) {
-                dbg("[STAGE3] generateStage3Proof: witness[0].PC (idx 6) = {any}\n", .{cycle_witnesses[0].values[6].toBytesBE()});
-                dbg("[STAGE3] generateStage3Proof: witness[0].UPC (idx 7) = {any}\n", .{cycle_witnesses[0].values[7].toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE3] generateStage3Proof: cycle_witnesses.len = {}\n", .{cycle_witnesses.len});
+                if (cycle_witnesses.len > 0) {
+                    dbg("[STAGE3] generateStage3Proof: witness[0].PC (idx 6) = {any}\n", .{cycle_witnesses[0].values[6].toBytesBE()});
+                    dbg("[STAGE3] generateStage3Proof: witness[0].UPC (idx 7) = {any}\n", .{cycle_witnesses[0].values[7].toBytesBE()});
+                }
+
+                dbg("[STAGE3] Starting with {} rounds, trace_len={}\n", .{ num_rounds, trace_len });
+
+                // DEBUG: Print transcript state BEFORE gamma derivation
+                dbg("\n[ZOLT] ========== STAGE 3 BEGIN ==========\n", .{});
+                dbg("[ZOLT] STAGE3_PRE: transcript_state = {{ {any} }}\n", .{transcript.state[0..16]});
             }
-
-            dbg("[STAGE3] Starting with {} rounds, trace_len={}\n", .{ num_rounds, trace_len });
-
-            // DEBUG: Print transcript state BEFORE gamma derivation
-            dbg("\n[ZOLT] ========== STAGE 3 BEGIN ==========\n", .{});
-            dbg("[ZOLT] STAGE3_PRE: transcript_state = {{ {any} }}\n", .{transcript.state[0..16]});
 
             // Phase 1: Derive parameters (BEFORE BatchedSumcheck::verify)
             // NOTE: Stage 3 uses challenge_scalar (NOT challenge_scalar_optimized) which means
@@ -153,9 +155,11 @@ pub fn Stage3Prover(comptime F: type) type {
             defer self.allocator.free(shift_gamma_powers);
 
             // Debug: Print all 5 gamma powers in LE bytes format for comparison
-            dbg("[ZOLT] STAGE3_SHIFT: gamma_powers[0] = {{ {any} }}\n", .{shift_gamma_powers[0].toBytes()});
-            dbg("[ZOLT] STAGE3_SHIFT: gamma_powers[1] = {{ {any} }}\n", .{shift_gamma_powers[1].toBytes()});
-            dbg("[ZOLT] STAGE3_SHIFT: gamma_powers[4] = {{ {any} }}\n", .{shift_gamma_powers[4].toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] STAGE3_SHIFT: gamma_powers[0] = {{ {any} }}\n", .{shift_gamma_powers[0].toBytes()});
+                dbg("[ZOLT] STAGE3_SHIFT: gamma_powers[1] = {{ {any} }}\n", .{shift_gamma_powers[1].toBytes()});
+                dbg("[ZOLT] STAGE3_SHIFT: gamma_powers[4] = {{ {any} }}\n", .{shift_gamma_powers[4].toBytes()});
+            }
 
             // InstructionInputParams::new - derive 1 gamma
             const instr_gamma = transcript.challengeScalarFull();
@@ -168,21 +172,27 @@ pub fn Stage3Prover(comptime F: type) type {
                 opening_claims,
                 shift_gamma_powers,
             );
-            dbg("[ZOLT] STAGE3_PRE: input_claim[0] (Shift) = {{ {any} }}\n", .{shift_input_claim.toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] STAGE3_PRE: input_claim[0] (Shift) = {{ {any} }}\n", .{shift_input_claim.toBytes()});
+            }
 
             const instr_input_claim = self.computeInstructionInputClaim(
                 opening_claims,
                 instr_gamma,
                 instr_gamma,
             );
-            dbg("[ZOLT] STAGE3_PRE: input_claim[1] (InstrInput) = {{ {any} }}\n", .{instr_input_claim.toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] STAGE3_PRE: input_claim[1] (InstrInput) = {{ {any} }}\n", .{instr_input_claim.toBytes()});
+            }
 
             const reg_input_claim = self.computeRegistersInputClaim(
                 opening_claims,
                 reg_gamma,
                 reg_gamma_sqr,
             );
-            dbg("[ZOLT] STAGE3_PRE: input_claim[2] (Registers) = {{ {any} }}\n", .{reg_input_claim.toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] STAGE3_PRE: input_claim[2] (Registers) = {{ {any} }}\n", .{reg_input_claim.toBytes()});
+            }
 
             // Phase 2: BatchedSumcheck::verify protocol
 
@@ -197,7 +207,9 @@ pub fn Stage3Prover(comptime F: type) type {
             for (0..3) |i| {
                 batching_coeffs[i] = transcript.challengeScalarFull();
             }
-            dbg("[ZOLT] STAGE3_PRE: batching_coeff[0] = {{ {any} }}\n", .{batching_coeffs[0].toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] STAGE3_PRE: batching_coeff[0] = {{ {any} }}\n", .{batching_coeffs[0].toBytes()});
+            }
 
             // Compute the combined initial claim
             var combined_claim = shift_input_claim.mul(batching_coeffs[0]);
@@ -307,12 +319,14 @@ pub fn Stage3Prover(comptime F: type) type {
 
             // Run sumcheck rounds
             for (0..num_rounds) |round| {
-                dbg("\n[ZOLT] STAGE3_ROUND_{}: current_claim = {{ {any} }}\n", .{ round, combined_claim.toBytes() });
+                if (comptime debug_verbose) {
+                    dbg("\n[ZOLT] STAGE3_ROUND_{}: current_claim = {{ {any} }}\n", .{ round, combined_claim.toBytes() });
 
-                // Print current shift/reg claims at phase transitions
-                if (round == 3) {
-                    dbg("[ZOLT] PHASE2_START_CLAIM: current_shift_claim = {{ {any} }}\n", .{current_shift_claim.toBytes()});
-                    dbg("[ZOLT] PHASE2_START_CLAIM: current_reg_claim = {{ {any} }}\n", .{current_reg_claim.toBytes()});
+                    // Print current shift/reg claims at phase transitions
+                    if (round == 3) {
+                        dbg("[ZOLT] PHASE2_START_CLAIM: current_shift_claim = {{ {any} }}\n", .{current_shift_claim.toBytes()});
+                        dbg("[ZOLT] PHASE2_START_CLAIM: current_reg_claim = {{ {any} }}\n", .{current_reg_claim.toBytes()});
+                    }
                 }
 
                 // Compute round polynomial for each instance
@@ -357,66 +371,70 @@ pub fn Stage3Prover(comptime F: type) type {
                 const reg_evals = reg_prover.computeRoundEvals(current_reg_claim);
 
                 // DEBUG: After last round, manually check the formula
-                if (round == num_rounds - 1) {
-                    dbg("[ZOLT] LAST_ROUND: instr_evals = [p0={{ {any} }}, p1={{ {any} }}, p2={{ {any} }}, p3={{ {any} }}]\n", .{
-                        instr_evals[0].toBytes()[0..8],
-                        instr_evals[1].toBytes()[0..8],
-                        instr_evals[2].toBytes()[0..8],
-                        instr_evals[3].toBytes()[0..8],
-                    });
+                if (comptime debug_verbose) {
+                    if (round == num_rounds - 1) {
+                        dbg("[ZOLT] LAST_ROUND: instr_evals = [p0={{ {any} }}, p1={{ {any} }}, p2={{ {any} }}, p3={{ {any} }}]\n", .{
+                            instr_evals[0].toBytes()[0..8],
+                            instr_evals[1].toBytes()[0..8],
+                            instr_evals[2].toBytes()[0..8],
+                            instr_evals[3].toBytes()[0..8],
+                        });
 
-                    // Manually compute what the polynomial value should be at different points
-                    // The prover should have current_size = 2 at this point
-                    dbg("[ZOLT] LAST_ROUND: instr_prover.current_size = {}\n", .{instr_prover.current_size});
+                        // Manually compute what the polynomial value should be at different points
+                        // The prover should have current_size = 2 at this point
+                        dbg("[ZOLT] LAST_ROUND: instr_prover.current_size = {}\n", .{instr_prover.current_size});
 
-                    // Check the sumcheck invariant: p(0) + p(1) = previous_claim
-                    const p0_plus_p1 = instr_evals[0].add(instr_evals[1]);
-                    dbg("[ZOLT] LAST_ROUND: p0+p1 = {{ {any} }}\n", .{p0_plus_p1.toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: current_instr_claim = {{ {any} }}\n", .{current_instr_claim.toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: sumcheck_invariant_ok = {}\n", .{p0_plus_p1.eql(current_instr_claim)});
+                        // Check the sumcheck invariant: p(0) + p(1) = previous_claim
+                        const p0_plus_p1 = instr_evals[0].add(instr_evals[1]);
+                        dbg("[ZOLT] LAST_ROUND: p0+p1 = {{ {any} }}\n", .{p0_plus_p1.toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: current_instr_claim = {{ {any} }}\n", .{current_instr_claim.toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: sumcheck_invariant_ok = {}\n", .{p0_plus_p1.eql(current_instr_claim)});
 
-                    // Manually compute what f(0) and f(1) should be from the raw values
-                    // Before bind, current_size = 2, so we have values at indices 0 and 1
-                    const left_0 = instr_prover.left_is_rs1[0].mul(instr_prover.rs1_value[0])
-                        .add(instr_prover.left_is_pc[0].mul(instr_prover.unexpanded_pc[0]));
-                    const right_0 = instr_prover.right_is_rs2[0].mul(instr_prover.rs2_value[0])
-                        .add(instr_prover.right_is_imm[0].mul(instr_prover.imm[0]));
-                    const eq_weight_0 = instr_prover.eq_stage2[0];
-                    const f_0 = eq_weight_0.mul(right_0.add(instr_gamma.mul(left_0)));
+                        // Manually compute what f(0) and f(1) should be from the raw values
+                        // Before bind, current_size = 2, so we have values at indices 0 and 1
+                        const left_0 = instr_prover.left_is_rs1[0].mul(instr_prover.rs1_value[0])
+                            .add(instr_prover.left_is_pc[0].mul(instr_prover.unexpanded_pc[0]));
+                        const right_0 = instr_prover.right_is_rs2[0].mul(instr_prover.rs2_value[0])
+                            .add(instr_prover.right_is_imm[0].mul(instr_prover.imm[0]));
+                        const eq_weight_0 = instr_prover.eq_stage2[0];
+                        const f_0 = eq_weight_0.mul(right_0.add(instr_gamma.mul(left_0)));
 
-                    const left_1 = instr_prover.left_is_rs1[1].mul(instr_prover.rs1_value[1])
-                        .add(instr_prover.left_is_pc[1].mul(instr_prover.unexpanded_pc[1]));
-                    const right_1 = instr_prover.right_is_rs2[1].mul(instr_prover.rs2_value[1])
-                        .add(instr_prover.right_is_imm[1].mul(instr_prover.imm[1]));
-                    const eq_weight_1 = instr_prover.eq_stage2[1];
-                    const f_1 = eq_weight_1.mul(right_1.add(instr_gamma.mul(left_1)));
+                        const left_1 = instr_prover.left_is_rs1[1].mul(instr_prover.rs1_value[1])
+                            .add(instr_prover.left_is_pc[1].mul(instr_prover.unexpanded_pc[1]));
+                        const right_1 = instr_prover.right_is_rs2[1].mul(instr_prover.rs2_value[1])
+                            .add(instr_prover.right_is_imm[1].mul(instr_prover.imm[1]));
+                        const eq_weight_1 = instr_prover.eq_stage2[1];
+                        const f_1 = eq_weight_1.mul(right_1.add(instr_gamma.mul(left_1)));
 
-                    dbg("[ZOLT] LAST_ROUND: manual_f0 = {{ {any} }}\n", .{f_0.toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: manual_f1 = {{ {any} }}\n", .{f_1.toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: f0_match = {}, f1_match = {}\n", .{ f_0.eql(instr_evals[0]), f_1.eql(instr_evals[1]) });
+                        dbg("[ZOLT] LAST_ROUND: manual_f0 = {{ {any} }}\n", .{f_0.toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: manual_f1 = {{ {any} }}\n", .{f_1.toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: f0_match = {}, f1_match = {}\n", .{ f_0.eql(instr_evals[0]), f_1.eql(instr_evals[1]) });
 
-                    // Check actual witness values at index 1
-                    dbg("[ZOLT] LAST_ROUND: left_is_rs1[1] = {{ {any} }}\n", .{instr_prover.left_is_rs1[1].toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: rs1_value[1] = {{ {any} }}\n", .{instr_prover.rs1_value[1].toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: eq_outer[1] = {{ {any} }}\n", .{instr_prover.eq_stage2[1].toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: eq_product[1] = {{ {any} }}\n", .{instr_prover.eq_stage2[1].toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: eq_weight_1 = {{ {any} }}\n", .{eq_weight_1.toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: left_1 = {{ {any} }}\n", .{left_1.toBytes()[0..8]});
-                    dbg("[ZOLT] LAST_ROUND: right_1 = {{ {any} }}\n", .{right_1.toBytes()[0..8]});
+                        // Check actual witness values at index 1
+                        dbg("[ZOLT] LAST_ROUND: left_is_rs1[1] = {{ {any} }}\n", .{instr_prover.left_is_rs1[1].toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: rs1_value[1] = {{ {any} }}\n", .{instr_prover.rs1_value[1].toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: eq_outer[1] = {{ {any} }}\n", .{instr_prover.eq_stage2[1].toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: eq_product[1] = {{ {any} }}\n", .{instr_prover.eq_stage2[1].toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: eq_weight_1 = {{ {any} }}\n", .{eq_weight_1.toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: left_1 = {{ {any} }}\n", .{left_1.toBytes()[0..8]});
+                        dbg("[ZOLT] LAST_ROUND: right_1 = {{ {any} }}\n", .{right_1.toBytes()[0..8]});
+                    }
                 }
 
                 // Debug: Check individual prover invariants (ALL rounds)
-                {
-                    const shift_sum = shift_evals[0].add(shift_evals[1]);
-                    const instr_sum = instr_evals[0].add(instr_evals[1]);
-                    const reg_sum = reg_evals[0].add(reg_evals[1]);
-                    dbg("[ZOLT] STAGE3_ROUND_{}: shift_p0+p1 = {{ {any} }}, shift_claim = {{ {any} }}, match={}\n", .{ round, shift_sum.toBytes()[0..8], current_shift_claim.toBytes()[0..8], shift_sum.eql(current_shift_claim) });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: instr_p0+p1 = {{ {any} }}, instr_claim = {{ {any} }}, match={}\n", .{ round, instr_sum.toBytes()[0..8], current_instr_claim.toBytes()[0..8], instr_sum.eql(current_instr_claim) });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: reg_p0+p1 = {{ {any} }}, reg_claim = {{ {any} }}, match={}\n", .{ round, reg_sum.toBytes()[0..8], current_reg_claim.toBytes()[0..8], reg_sum.eql(current_reg_claim) });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: shift_phase = {s}, reg_phase = {s}\n", .{ round, if (shift_prover.in_phase2) "PHASE2" else "PHASE1", if (reg_prover.in_phase2) "PHASE2" else "PHASE1" });
+                if (comptime debug_verbose) {
+                    {
+                        const shift_sum = shift_evals[0].add(shift_evals[1]);
+                        const instr_sum = instr_evals[0].add(instr_evals[1]);
+                        const reg_sum = reg_evals[0].add(reg_evals[1]);
+                        dbg("[ZOLT] STAGE3_ROUND_{}: shift_p0+p1 = {{ {any} }}, shift_claim = {{ {any} }}, match={}\n", .{ round, shift_sum.toBytes()[0..8], current_shift_claim.toBytes()[0..8], shift_sum.eql(current_shift_claim) });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: instr_p0+p1 = {{ {any} }}, instr_claim = {{ {any} }}, match={}\n", .{ round, instr_sum.toBytes()[0..8], current_instr_claim.toBytes()[0..8], instr_sum.eql(current_instr_claim) });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: reg_p0+p1 = {{ {any} }}, reg_claim = {{ {any} }}, match={}\n", .{ round, reg_sum.toBytes()[0..8], current_reg_claim.toBytes()[0..8], reg_sum.eql(current_reg_claim) });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: shift_phase = {s}, reg_phase = {s}\n", .{ round, if (shift_prover.in_phase2) "PHASE2" else "PHASE1", if (reg_prover.in_phase2) "PHASE2" else "PHASE1" });
+                    }
+                    dbg("[ZOLT] STAGE3_ROUND_{}: shift_p0 = {{ {any} }}\n", .{ round, shift_evals[0].toBytes() });
+                    dbg("[ZOLT] STAGE3_ROUND_{}: shift_p1 = {{ {any} }}\n", .{ round, shift_evals[1].toBytes() });
                 }
-                dbg("[ZOLT] STAGE3_ROUND_{}: shift_p0 = {{ {any} }}\n", .{ round, shift_evals[0].toBytes() });
-                dbg("[ZOLT] STAGE3_ROUND_{}: shift_p1 = {{ {any} }}\n", .{ round, shift_evals[1].toBytes() });
 
                 // Combine round polynomials (all evaluated at 0, 1, 2, 3)
                 // batched_poly = coeff[0] * shift_poly + coeff[1] * instr_poly + coeff[2] * reg_poly
@@ -437,11 +455,13 @@ pub fn Stage3Prover(comptime F: type) type {
                 }
 
                 // Debug: Print evaluations
-                if (round < 3) {
-                    dbg("[ZOLT] STAGE3_ROUND_{}: p0 = {{ {any} }}\n", .{ round, combined_evals[0].toBytes() });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: p1 = {{ {any} }}\n", .{ round, combined_evals[1].toBytes() });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: p0+p1 = {{ {any} }}\n", .{ round, combined_evals[0].add(combined_evals[1]).toBytes() });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: current_claim (should match p0+p1) = {{ {any} }}\n", .{ round, combined_claim.toBytes() });
+                if (comptime debug_verbose) {
+                    if (round < 3) {
+                        dbg("[ZOLT] STAGE3_ROUND_{}: p0 = {{ {any} }}\n", .{ round, combined_evals[0].toBytes() });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: p1 = {{ {any} }}\n", .{ round, combined_evals[1].toBytes() });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: p0+p1 = {{ {any} }}\n", .{ round, combined_evals[0].add(combined_evals[1]).toBytes() });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: current_claim (should match p0+p1) = {{ {any} }}\n", .{ round, combined_claim.toBytes() });
+                    }
                 }
 
                 // Convert evaluations to coefficients
@@ -449,8 +469,10 @@ pub fn Stage3Prover(comptime F: type) type {
                 defer self.allocator.free(combined_coeffs);
 
                 // Debug: Print all coefficients including c1
-                if (round < 3) {
-                    dbg("[ZOLT] STAGE3_ROUND_{}: c1 = {{ {any} }}\n", .{ round, combined_coeffs[1].toBytes() });
+                if (comptime debug_verbose) {
+                    if (round < 3) {
+                        dbg("[ZOLT] STAGE3_ROUND_{}: c1 = {{ {any} }}\n", .{ round, combined_coeffs[1].toBytes() });
+                    }
                 }
 
                 // Compress: [c0, c2, c3] (c1 recovered from hint = combined_claim)
@@ -469,19 +491,25 @@ pub fn Stage3Prover(comptime F: type) type {
                 transcript.appendScalars("sumcheck_poly", compressed);
 
                 // Debug: Print compressed coefficients
-                dbg("[ZOLT] STAGE3_ROUND_{}: c0 = {{ {any} }}\n", .{ round, compressed[0].toBytes() });
-                dbg("[ZOLT] STAGE3_ROUND_{}: c2 = {{ {any} }}\n", .{ round, compressed[1].toBytes() });
-                dbg("[ZOLT] STAGE3_ROUND_{}: c3 = {{ {any} }}\n", .{ round, compressed[2].toBytes() });
+                if (comptime debug_verbose) {
+                    dbg("[ZOLT] STAGE3_ROUND_{}: c0 = {{ {any} }}\n", .{ round, compressed[0].toBytes() });
+                    dbg("[ZOLT] STAGE3_ROUND_{}: c2 = {{ {any} }}\n", .{ round, compressed[1].toBytes() });
+                    dbg("[ZOLT] STAGE3_ROUND_{}: c3 = {{ {any} }}\n", .{ round, compressed[2].toBytes() });
+                }
 
                 // Derive challenge
                 const r_j = transcript.challengeScalar();
                 challenges[round] = r_j;
 
-                dbg("[ZOLT] STAGE3_ROUND_{}: challenge = {{ {any} }}\n", .{ round, r_j.toBytes() });
+                if (comptime debug_verbose) {
+                    dbg("[ZOLT] STAGE3_ROUND_{}: challenge = {{ {any} }}\n", .{ round, r_j.toBytes() });
+                }
 
                 // Evaluate combined polynomial at r_j to get next claim
                 combined_claim = self.evaluatePolyAtPoint(combined_coeffs, r_j);
-                dbg("[ZOLT] STAGE3_ROUND_{}: next_claim = {{ {any} }}\n", .{ round, combined_claim.toBytes() });
+                if (comptime debug_verbose) {
+                    dbg("[ZOLT] STAGE3_ROUND_{}: next_claim = {{ {any} }}\n", .{ round, combined_claim.toBytes() });
+                }
 
                 // Update individual claims by evaluating their polynomials at r_j
                 const shift_coeffs = try self.evalsToCoeffs(&shift_evals, 2);
@@ -497,25 +525,27 @@ pub fn Stage3Prover(comptime F: type) type {
                 current_reg_claim = self.evaluatePolyAtPoint(reg_coeffs, r_j);
 
                 // DEBUG: Verify combined_claim equals batched sum of individual claims
-                if (round < 3) {
-                    // Test: evaluate combined poly at point 0 - should equal combined_evals[0]
-                    const test_p0 = self.evaluatePolyAtPoint(combined_coeffs, F.zero());
-                    const expect_p0 = combined_evals[0];
-                    dbg("[ZOLT] STAGE3_ROUND_{}: combined_poly(0) = {{ {any} }}, expect = {{ {any} }}, match={}\n", .{ round, test_p0.toBytes()[0..8], expect_p0.toBytes()[0..8], test_p0.eql(expect_p0) });
+                if (comptime debug_verbose) {
+                    if (round < 3) {
+                        // Test: evaluate combined poly at point 0 - should equal combined_evals[0]
+                        const test_p0 = self.evaluatePolyAtPoint(combined_coeffs, F.zero());
+                        const expect_p0 = combined_evals[0];
+                        dbg("[ZOLT] STAGE3_ROUND_{}: combined_poly(0) = {{ {any} }}, expect = {{ {any} }}, match={}\n", .{ round, test_p0.toBytes()[0..8], expect_p0.toBytes()[0..8], test_p0.eql(expect_p0) });
 
-                    // Direct sum check
-                    const direct_combined = batching_coeffs[0].mul(self.evaluatePolyAtPoint(shift_coeffs, r_j))
-                        .add(batching_coeffs[1].mul(self.evaluatePolyAtPoint(instr_coeffs, r_j)))
-                        .add(batching_coeffs[2].mul(self.evaluatePolyAtPoint(reg_coeffs, r_j)));
-                    dbg("[ZOLT] STAGE3_ROUND_{}: direct_combined = {{ {any} }}\n", .{ round, direct_combined.toBytes()[0..8] });
-                    dbg("[ZOLT] STAGE3_ROUND_{}: combined_claim = {{ {any} }}\n", .{ round, combined_claim.toBytes()[0..8] });
+                        // Direct sum check
+                        const direct_combined = batching_coeffs[0].mul(self.evaluatePolyAtPoint(shift_coeffs, r_j))
+                            .add(batching_coeffs[1].mul(self.evaluatePolyAtPoint(instr_coeffs, r_j)))
+                            .add(batching_coeffs[2].mul(self.evaluatePolyAtPoint(reg_coeffs, r_j)));
+                        dbg("[ZOLT] STAGE3_ROUND_{}: direct_combined = {{ {any} }}\n", .{ round, direct_combined.toBytes()[0..8] });
+                        dbg("[ZOLT] STAGE3_ROUND_{}: combined_claim = {{ {any} }}\n", .{ round, combined_claim.toBytes()[0..8] });
 
-                    const batched_sum = batching_coeffs[0].mul(current_shift_claim)
-                        .add(batching_coeffs[1].mul(current_instr_claim))
-                        .add(batching_coeffs[2].mul(current_reg_claim));
-                    dbg("[ZOLT] STAGE3_ROUND_{}: batched_sum = {{ {any} }}\n", .{ round, batched_sum.toBytes()[0..8] });
-                    if (!batched_sum.eql(combined_claim)) {
-                        dbg("[ZOLT] STAGE3_ROUND_{}: MISMATCH: batched_sum != combined_claim!\n", .{round});
+                        const batched_sum = batching_coeffs[0].mul(current_shift_claim)
+                            .add(batching_coeffs[1].mul(current_instr_claim))
+                            .add(batching_coeffs[2].mul(current_reg_claim));
+                        dbg("[ZOLT] STAGE3_ROUND_{}: batched_sum = {{ {any} }}\n", .{ round, batched_sum.toBytes()[0..8] });
+                        if (!batched_sum.eql(combined_claim)) {
+                            dbg("[ZOLT] STAGE3_ROUND_{}: MISMATCH: batched_sum != combined_claim!\n", .{round});
+                        }
                     }
                 }
 
@@ -581,10 +611,12 @@ pub fn Stage3Prover(comptime F: type) type {
                 }
             }
 
-            dbg("\n[ZOLT] STAGE3_FINAL: output_claim = {{ {any} }}\n", .{combined_claim.toBytes()});
+            if (comptime debug_verbose) {
+                dbg("\n[ZOLT] STAGE3_FINAL: output_claim = {{ {any} }}\n", .{combined_claim.toBytes()});
+            }
 
             // DEBUG: Compute expected_output_claim like verifier
-            {
+            if (comptime debug_verbose) {
                 // Get final opening claims from provers
                 const s_claims = shift_prover.finalClaims();
                 const i_claims = instr_prover.finalClaims();
@@ -723,7 +755,7 @@ pub fn Stage3Prover(comptime F: type) type {
             const reg_claims = reg_prover.finalClaims();
 
             // CRITICAL DIAGNOSTIC: Verify reg_claims match MLE at challenges
-            {
+            if (comptime debug_verbose) {
                 // Build eq(challenges, j) table
                 const eq_check = self.allocator.alloc(F, trace_len) catch unreachable;
                 defer self.allocator.free(eq_check);
@@ -839,102 +871,138 @@ pub fn Stage3Prover(comptime F: type) type {
             }
 
             // DEBUG: Print opening claims
-            dbg("\n[ZOLT] STAGE3_OPENING: Shift sumcheck claims:\n", .{});
-            dbg("[ZOLT] STAGE3_OPENING: unexpanded_pc = {{ {any} }}\n", .{shift_claims.unexpanded_pc.toBytes()});
-            dbg("[ZOLT] STAGE3_OPENING: pc = {{ {any} }}\n", .{shift_claims.pc.toBytes()});
-            dbg("[ZOLT] STAGE3_OPENING: is_noop = {{ {any} }}\n", .{shift_claims.is_noop.toBytes()});
+            if (comptime debug_verbose) {
+                dbg("\n[ZOLT] STAGE3_OPENING: Shift sumcheck claims:\n", .{});
+                dbg("[ZOLT] STAGE3_OPENING: unexpanded_pc = {{ {any} }}\n", .{shift_claims.unexpanded_pc.toBytes()});
+                dbg("[ZOLT] STAGE3_OPENING: pc = {{ {any} }}\n", .{shift_claims.pc.toBytes()});
+                dbg("[ZOLT] STAGE3_OPENING: is_noop = {{ {any} }}\n", .{shift_claims.is_noop.toBytes()});
+            }
 
             // Append opening claims to transcript (cache_openings)
             // ShiftSumcheck: 5 claims
-            dbg("\n[ZOLT cache_openings] ShiftSumcheck claims appended to transcript:\n", .{});
-            dbg("  [0] unexpanded_pc LE = {{ ", .{});
-            for (shift_claims.unexpanded_pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("\n[ZOLT cache_openings] ShiftSumcheck claims appended to transcript:\n", .{});
+                dbg("  [0] unexpanded_pc LE = {{ ", .{});
+                for (shift_claims.unexpanded_pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", shift_claims.unexpanded_pc);
 
-            dbg("  [1] pc LE = {{ ", .{});
-            for (shift_claims.pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [1] pc LE = {{ ", .{});
+                for (shift_claims.pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", shift_claims.pc);
 
-            dbg("  [2] is_virtual LE = {{ ", .{});
-            for (shift_claims.is_virtual.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [2] is_virtual LE = {{ ", .{});
+                for (shift_claims.is_virtual.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", shift_claims.is_virtual);
 
-            dbg("  [3] is_first_in_sequence LE = {{ ", .{});
-            for (shift_claims.is_first_in_sequence.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [3] is_first_in_sequence LE = {{ ", .{});
+                for (shift_claims.is_first_in_sequence.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", shift_claims.is_first_in_sequence);
 
-            dbg("  [4] is_noop LE = {{ ", .{});
-            for (shift_claims.is_noop.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [4] is_noop LE = {{ ", .{});
+                for (shift_claims.is_noop.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", shift_claims.is_noop);
 
             // InstructionInputSumcheck: 8 claims
-            dbg("[ZOLT cache_openings] InstructionInputVirtualization claims:\n", .{});
-            dbg("  [5] left_is_rs1 LE = {{ ", .{});
-            for (instr_claims.left_is_rs1.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT cache_openings] InstructionInputVirtualization claims:\n", .{});
+                dbg("  [5] left_is_rs1 LE = {{ ", .{});
+                for (instr_claims.left_is_rs1.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.left_is_rs1);
 
-            dbg("  [6] rs1_value LE = {{ ", .{});
-            for (instr_claims.rs1_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [6] rs1_value LE = {{ ", .{});
+                for (instr_claims.rs1_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.rs1_value);
 
-            dbg("  [7] left_is_pc LE = {{ ", .{});
-            for (instr_claims.left_is_pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [7] left_is_pc LE = {{ ", .{});
+                for (instr_claims.left_is_pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.left_is_pc);
 
-            dbg("  [8] unexpanded_pc LE = {{ ", .{});
-            for (instr_claims.unexpanded_pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}} (ALIASED - same poly UnexpandedPC at same point as Shift)\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [8] unexpanded_pc LE = {{ ", .{});
+                for (instr_claims.unexpanded_pc.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}} (ALIASED - same poly UnexpandedPC at same point as Shift)\n", .{});
+            }
             // ALIASED: UnexpandedPC already opened at same point by ShiftSumcheck — not flushed to transcript
 
-            dbg("  [9] right_is_rs2 LE = {{ ", .{});
-            for (instr_claims.right_is_rs2.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [9] right_is_rs2 LE = {{ ", .{});
+                for (instr_claims.right_is_rs2.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.right_is_rs2);
 
-            dbg("  [10] rs2_value LE = {{ ", .{});
-            for (instr_claims.rs2_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [10] rs2_value LE = {{ ", .{});
+                for (instr_claims.rs2_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.rs2_value);
 
-            dbg("  [11] right_is_imm LE = {{ ", .{});
-            for (instr_claims.right_is_imm.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [11] right_is_imm LE = {{ ", .{});
+                for (instr_claims.right_is_imm.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.right_is_imm);
 
-            dbg("  [12] imm LE = {{ ", .{});
-            for (instr_claims.imm.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [12] imm LE = {{ ", .{});
+                for (instr_claims.imm.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", instr_claims.imm);
 
             // RegistersClaimReduction: 3 claims
-            dbg("[ZOLT cache_openings] RegistersClaimReduction claims:\n", .{});
-            dbg("  [13] rd_write_value LE = {{ ", .{});
-            for (reg_claims.rd_write_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT cache_openings] RegistersClaimReduction claims:\n", .{});
+                dbg("  [13] rd_write_value LE = {{ ", .{});
+                for (reg_claims.rd_write_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}}\n", .{});
+            }
             transcript.appendScalar("opening_claim", reg_claims.rd_write_value);
 
-            dbg("  [14] rs1_value LE = {{ ", .{});
-            for (reg_claims.rs1_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}} (ALIASED - same poly Rs1Value at same point as InstrInput)\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [14] rs1_value LE = {{ ", .{});
+                for (reg_claims.rs1_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}} (ALIASED - same poly Rs1Value at same point as InstrInput)\n", .{});
+            }
             // ALIASED: Rs1Value already opened at same point by InstructionInputSumcheck — not flushed
 
-            dbg("  [15] rs2_value LE = {{ ", .{});
-            for (reg_claims.rs2_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
-            dbg("}} (ALIASED - same poly Rs2Value at same point as InstrInput)\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  [15] rs2_value LE = {{ ", .{});
+                for (reg_claims.rs2_value.toBytes()) |b| dbg("{x:0>2}, ", .{b});
+                dbg("}} (ALIASED - same poly Rs2Value at same point as InstrInput)\n", .{});
+            }
             // ALIASED: Rs2Value already opened at same point by InstructionInputSumcheck — not flushed
 
             // Print transcript state after cache_openings
-            dbg("[ZOLT cache_openings] Transcript state AFTER all 13 claims (3 aliased): {{ ", .{});
-            for (transcript.state[0..8]) |b| dbg("{x:0>2} ", .{b});
-            dbg("}}\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT cache_openings] Transcript state AFTER all 13 claims (3 aliased): {{ ", .{});
+                for (transcript.state[0..8]) |b| dbg("{x:0>2} ", .{b});
+                dbg("}}\n", .{});
+            }
 
             if (comptime debug_verbose) {
                 // Print transcript state and key claims for comparison with Jolt
@@ -1025,15 +1093,17 @@ pub fn Stage3Prover(comptime F: type) type {
             const next_is_first = opening_claims.get(.{ .Virtual = .{ .poly = .NextIsFirstInSequence, .sumcheck_id = .SpartanOuter } }) orelse F.zero();
             const next_is_noop = opening_claims.get(.{ .Virtual = .{ .poly = .NextIsNoop, .sumcheck_id = .SpartanProductVirtualization } }) orelse F.zero();
 
-            dbg("[ZOLT] SHIFT_INPUT: next_unexpanded_pc = {{ {any} }}\n", .{next_unexpanded_pc.toBytes()});
-            dbg("[ZOLT] SHIFT_INPUT: next_pc = {{ {any} }}\n", .{next_pc.toBytes()});
-            dbg("[ZOLT] SHIFT_INPUT: next_is_virtual = {{ {any} }}\n", .{next_is_virtual.toBytes()});
-            dbg("[ZOLT] SHIFT_INPUT: next_is_first = {{ {any} }}\n", .{next_is_first.toBytes()});
-            dbg("[ZOLT] SHIFT_INPUT: next_is_noop = {{ {any} }}\n", .{next_is_noop.toBytes()});
-            dbg("[ZOLT] SHIFT_INPUT: gamma_powers[4] = {{ {any} }}\n", .{gamma_powers[4].toBytes()});
-            // Also verify the input claim is correctly computed
-            dbg("[ZOLT] SHIFT_INPUT: 1 - next_is_noop = {{ {any} }}\n", .{F.one().sub(next_is_noop).toBytes()});
-            dbg("[ZOLT] SHIFT_INPUT: gamma^4 * (1-noop) = {{ {any} }}\n", .{gamma_powers[4].mul(F.one().sub(next_is_noop)).toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] SHIFT_INPUT: next_unexpanded_pc = {{ {any} }}\n", .{next_unexpanded_pc.toBytes()});
+                dbg("[ZOLT] SHIFT_INPUT: next_pc = {{ {any} }}\n", .{next_pc.toBytes()});
+                dbg("[ZOLT] SHIFT_INPUT: next_is_virtual = {{ {any} }}\n", .{next_is_virtual.toBytes()});
+                dbg("[ZOLT] SHIFT_INPUT: next_is_first = {{ {any} }}\n", .{next_is_first.toBytes()});
+                dbg("[ZOLT] SHIFT_INPUT: next_is_noop = {{ {any} }}\n", .{next_is_noop.toBytes()});
+                dbg("[ZOLT] SHIFT_INPUT: gamma_powers[4] = {{ {any} }}\n", .{gamma_powers[4].toBytes()});
+                // Also verify the input claim is correctly computed
+                dbg("[ZOLT] SHIFT_INPUT: 1 - next_is_noop = {{ {any} }}\n", .{F.one().sub(next_is_noop).toBytes()});
+                dbg("[ZOLT] SHIFT_INPUT: gamma^4 * (1-noop) = {{ {any} }}\n", .{gamma_powers[4].mul(F.one().sub(next_is_noop)).toBytes()});
+            }
 
             var result = next_unexpanded_pc;
             result = result.add(gamma_powers[1].mul(next_pc));
@@ -1627,9 +1697,11 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
             }
 
             // DEBUG: Verify sumcheck invariant p(0) + p(1) = previous_claim
-            const computed_sum = evals[0].add(evals[1]);
-            if (!computed_sum.eql(previous_claim)) {
-                dbg("[ZOLT] SHIFT INVARIANT FAIL: p(0)+p(1) = {{ {any} }}, expected = {{ {any} }}\n", .{ computed_sum.toBytes(), previous_claim.toBytes() });
+            if (comptime debug_verbose) {
+                const computed_sum = evals[0].add(evals[1]);
+                if (!computed_sum.eql(previous_claim)) {
+                    dbg("[ZOLT] SHIFT INVARIANT FAIL: p(0)+p(1) = {{ {any} }}, expected = {{ {any} }}\n", .{ computed_sum.toBytes(), previous_claim.toBytes() });
+                }
             }
 
             return evals;
@@ -1647,16 +1719,18 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
             var evals: [2]F = .{ F.zero(), F.zero() };
 
             // Debug: Print arrays when they're size 2 (last Phase 2 round)
-            if (self.current_witness_size == 2) {
-                dbg("[ZOLT] SHIFT_LAST_ROUND: eq_outer[0] = {{ {any} }}\n", .{eq_outer[0].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: eq_outer[1] = {{ {any} }}\n", .{eq_outer[1].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: eq_prod[0] = {{ {any} }}\n", .{eq_prod[0].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: eq_prod[1] = {{ {any} }}\n", .{eq_prod[1].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: upc[0] = {{ {any} }}\n", .{self.unexpanded_pc[0].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: upc[1] = {{ {any} }}\n", .{self.unexpanded_pc[1].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: noop[0] = {{ {any} }}\n", .{self.is_noop[0].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: noop[1] = {{ {any} }}\n", .{self.is_noop[1].toBytes()});
-                dbg("[ZOLT] SHIFT_LAST_ROUND: previous_claim = {{ {any} }}\n", .{previous_claim.toBytes()});
+            if (comptime debug_verbose) {
+                if (self.current_witness_size == 2) {
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: eq_outer[0] = {{ {any} }}\n", .{eq_outer[0].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: eq_outer[1] = {{ {any} }}\n", .{eq_outer[1].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: eq_prod[0] = {{ {any} }}\n", .{eq_prod[0].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: eq_prod[1] = {{ {any} }}\n", .{eq_prod[1].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: upc[0] = {{ {any} }}\n", .{self.unexpanded_pc[0].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: upc[1] = {{ {any} }}\n", .{self.unexpanded_pc[1].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: noop[0] = {{ {any} }}\n", .{self.is_noop[0].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: noop[1] = {{ {any} }}\n", .{self.is_noop[1].toBytes()});
+                    dbg("[ZOLT] SHIFT_LAST_ROUND: previous_claim = {{ {any} }}\n", .{previous_claim.toBytes()});
+                }
             }
 
             for (0..half) |j| {
@@ -1705,23 +1779,25 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
                 evals[1] = evals[1].add(f_2);
 
                 // Debug: last round details
-                if (eq_outer.len == 2) {
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: f(0) = {{ {any} }}\n", .{f_0.toBytes()});
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: f(2) = {{ {any} }}\n", .{f_2.toBytes()});
+                if (comptime debug_verbose) {
+                    if (eq_outer.len == 2) {
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: f(0) = {{ {any} }}\n", .{f_0.toBytes()});
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: f(2) = {{ {any} }}\n", .{f_2.toBytes()});
 
-                    // Compute f(1) = eq_out_1 * val_1 + γ⁴*(1-noop_1)*eq_prod_1
-                    const val_1 = upc_1.add(self.gamma_powers[1].mul(pc_1))
-                        .add(self.gamma_powers[2].mul(virt_1))
-                        .add(self.gamma_powers[3].mul(first_1));
-                    const actual_f1 = eq_out_1.mul(val_1)
-                        .add(self.gamma_powers[4].mul(F.one().sub(noop_1)).mul(eq_prod_1));
-                    const derived_f1 = previous_claim.sub(f_0);
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: actual_f(1) = {{ {any} }}\n", .{actual_f1.toBytes()});
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: derived_f(1) = {{ {any} }}\n", .{derived_f1.toBytes()});
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: f(1) match = {}\n", .{actual_f1.eql(derived_f1)});
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: f(0)+actual_f(1) = {{ {any} }}\n", .{f_0.add(actual_f1).toBytes()});
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: claim = {{ {any} }}\n", .{previous_claim.toBytes()});
-                    dbg("[ZOLT] SHIFT_LAST_ROUND: f(0)+actual_f(1)==claim: {}\n", .{f_0.add(actual_f1).eql(previous_claim)});
+                        // Compute f(1) = eq_out_1 * val_1 + γ⁴*(1-noop_1)*eq_prod_1
+                        const val_1 = upc_1.add(self.gamma_powers[1].mul(pc_1))
+                            .add(self.gamma_powers[2].mul(virt_1))
+                            .add(self.gamma_powers[3].mul(first_1));
+                        const actual_f1 = eq_out_1.mul(val_1)
+                            .add(self.gamma_powers[4].mul(F.one().sub(noop_1)).mul(eq_prod_1));
+                        const derived_f1 = previous_claim.sub(f_0);
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: actual_f(1) = {{ {any} }}\n", .{actual_f1.toBytes()});
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: derived_f(1) = {{ {any} }}\n", .{derived_f1.toBytes()});
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: f(1) match = {}\n", .{actual_f1.eql(derived_f1)});
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: f(0)+actual_f(1) = {{ {any} }}\n", .{f_0.add(actual_f1).toBytes()});
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: claim = {{ {any} }}\n", .{previous_claim.toBytes()});
+                        dbg("[ZOLT] SHIFT_LAST_ROUND: f(0)+actual_f(1)==claim: {}\n", .{f_0.add(actual_f1).eql(previous_claim)});
+                    }
                 }
             }
 
@@ -1812,8 +1888,10 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
             const n_remaining_rounds = self.suffix_n_vars;
             const suffix_size: usize = @as(usize, 1) << @intCast(n_remaining_rounds);
 
-            dbg("\n[ZOLT] SHIFT_PHASE2_START: n_remaining_rounds={d}, suffix_size={d}\n", .{ n_remaining_rounds, suffix_size });
-            dbg("[ZOLT] SHIFT_PHASE2_START: r_prefix_be.len={d}\n", .{r_prefix_be.len});
+            if (comptime debug_verbose) {
+                dbg("\n[ZOLT] SHIFT_PHASE2_START: n_remaining_rounds={d}, suffix_size={d}\n", .{ n_remaining_rounds, suffix_size });
+                dbg("[ZOLT] SHIFT_PHASE2_START: r_prefix_be.len={d}\n", .{r_prefix_be.len});
+            }
 
             // =====================================================================
             // Step 1: Regenerate prefix-suffix decomposition from original r_outer/r_product
@@ -1854,17 +1932,19 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
             const prefix_1_eval_outer = evaluateMle(prefix_1_outer, r_prefix_le);
 
             // DEBUG: Print prefix evaluation details
-            dbg("[ZOLT] SHIFT_PREFIX: r_prefix_be[0] = {any}\n", .{r_prefix_be[0].toBytes()[0..8]});
-            dbg("[ZOLT] SHIFT_PREFIX: r_prefix_be[last] = {any}\n", .{r_prefix_be[r_prefix_be.len - 1].toBytes()[0..8]});
-            dbg("[ZOLT] SHIFT_PREFIX: prefix_0_eval_outer = {any}\n", .{prefix_0_eval_outer.toBytes()[0..8]});
-            dbg("[ZOLT] SHIFT_PREFIX: prefix_1_eval_outer = {any}\n", .{prefix_1_eval_outer.toBytes()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] SHIFT_PREFIX: r_prefix_be[0] = {any}\n", .{r_prefix_be[0].toBytes()[0..8]});
+                dbg("[ZOLT] SHIFT_PREFIX: r_prefix_be[last] = {any}\n", .{r_prefix_be[r_prefix_be.len - 1].toBytes()[0..8]});
+                dbg("[ZOLT] SHIFT_PREFIX: prefix_0_eval_outer = {any}\n", .{prefix_0_eval_outer.toBytes()[0..8]});
+                dbg("[ZOLT] SHIFT_PREFIX: prefix_1_eval_outer = {any}\n", .{prefix_1_eval_outer.toBytes()[0..8]});
 
-            // DEBUG: Print r_outer_hi and r_outer_lo (the fixed points from Stage 1)
-            // Using BE for comparison with STAGE1_CHALLENGES output
-            dbg("[ZOLT] SHIFT_PREFIX: r_outer_hi[0] (BE) = {any}\n", .{r_outer_hi[0].toBytesBE()[0..8]});
-            dbg("[ZOLT] SHIFT_PREFIX: r_outer_hi[last] (BE) = {any}\n", .{r_outer_hi[r_outer_hi.len - 1].toBytesBE()[0..8]});
-            dbg("[ZOLT] SHIFT_PREFIX: r_outer_lo[0] (BE) = {any}\n", .{r_outer_lo[0].toBytesBE()[0..8]});
-            dbg("[ZOLT] SHIFT_PREFIX: r_outer_lo[last] (BE) = {any}\n", .{r_outer_lo[r_outer_lo.len - 1].toBytesBE()[0..8]});
+                // DEBUG: Print r_outer_hi and r_outer_lo (the fixed points from Stage 1)
+                // Using BE for comparison with STAGE1_CHALLENGES output
+                dbg("[ZOLT] SHIFT_PREFIX: r_outer_hi[0] (BE) = {any}\n", .{r_outer_hi[0].toBytesBE()[0..8]});
+                dbg("[ZOLT] SHIFT_PREFIX: r_outer_hi[last] (BE) = {any}\n", .{r_outer_hi[r_outer_hi.len - 1].toBytesBE()[0..8]});
+                dbg("[ZOLT] SHIFT_PREFIX: r_outer_lo[0] (BE) = {any}\n", .{r_outer_lo[0].toBytesBE()[0..8]});
+                dbg("[ZOLT] SHIFT_PREFIX: r_outer_lo[last] (BE) = {any}\n", .{r_outer_lo[r_outer_lo.len - 1].toBytesBE()[0..8]});
+            }
 
             // Regenerate suffix polynomials for r_outer
             // SUFFIX uses r_hi (Jolt convention)
@@ -1983,100 +2063,102 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
 
             self.current_witness_size = suffix_size;
 
-            dbg("[ZOLT] SHIFT_PHASE2_START: eq+1_outer[0] = {{ {any} }}\n", .{self.phase2_eq_plus_one_outer.?[0].toBytes()[0..8]});
-            dbg("[ZOLT] SHIFT_PHASE2_START: unexpanded_pc[0] = {{ {any} }}\n", .{self.unexpanded_pc[0].toBytes()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[ZOLT] SHIFT_PHASE2_START: eq+1_outer[0] = {{ {any} }}\n", .{self.phase2_eq_plus_one_outer.?[0].toBytes()[0..8]});
+                dbg("[ZOLT] SHIFT_PHASE2_START: unexpanded_pc[0] = {{ {any} }}\n", .{self.unexpanded_pc[0].toBytes()[0..8]});
 
-            // CRITICAL VERIFICATION: Compute Σ_j f(j) using Phase 2 data
-            // This should equal the current_shift_claim at the start of Phase 2
-            {
-                var phase2_total_sum = F.zero();
-                for (0..suffix_size) |j| {
-                    const eq_out = self.phase2_eq_plus_one_outer.?[j];
-                    const eq_prod = self.phase2_eq_plus_one_prod.?[j];
-                    const upc = self.unexpanded_pc[j];
-                    const pc_val = self.pc[j];
-                    const virt = self.is_virtual[j];
-                    const first = self.is_first_in_sequence[j];
-                    const noop = self.is_noop[j];
+                // CRITICAL VERIFICATION: Compute Σ_j f(j) using Phase 2 data
+                // This should equal the current_shift_claim at the start of Phase 2
+                {
+                    var phase2_total_sum = F.zero();
+                    for (0..suffix_size) |j| {
+                        const eq_out = self.phase2_eq_plus_one_outer.?[j];
+                        const eq_prod_v = self.phase2_eq_plus_one_prod.?[j];
+                        const upc = self.unexpanded_pc[j];
+                        const pc_val = self.pc[j];
+                        const virt = self.is_virtual[j];
+                        const first = self.is_first_in_sequence[j];
+                        const noop = self.is_noop[j];
 
-                    const val = upc.add(self.gamma_powers[1].mul(pc_val))
-                        .add(self.gamma_powers[2].mul(virt))
-                        .add(self.gamma_powers[3].mul(first));
-                    const term1 = eq_out.mul(val);
-                    const term2 = self.gamma_powers[4].mul(F.one().sub(noop)).mul(eq_prod);
-                    phase2_total_sum = phase2_total_sum.add(term1).add(term2);
-                }
-                dbg("[ZOLT] SHIFT_PHASE2_VERIFY: phase2_total_sum = {{ {any} }}\n", .{phase2_total_sum.toBytes()});
-                dbg("[ZOLT] SHIFT_PHASE2_VERIFY: (compare with current_shift_claim at Phase2 start)\n", .{});
-            }
-
-            // DEBUG: Verify eq+1_outer initialization by direct evaluation
-            {
-                // eq+1_outer[0] should equal eq+1(r_outer, (r_prefix_be, [0,0,...,0]))
-                // where [0,0,...,0] is all zeros (suffix_n_vars zeros)
-                // This is: prefix_0_eval * suffix_0[0] + prefix_1_eval * suffix_1[0]
-
-                // First, verify suffix_0[0] = eq(r_outer_hi, [0,...,0])
-                // eq([r0,r1,...], [0,0,...]) should be prod(1-ri)
-                var expected_suffix_0_at_0 = F.one();
-                for (r_outer_hi) |ri| {
-                    expected_suffix_0_at_0 = expected_suffix_0_at_0.mul(F.one().sub(ri));
-                }
-                dbg("[ZOLT] SHIFT_DEBUG: expected suffix_0[0] = {any}\n", .{expected_suffix_0_at_0.toBytes()[0..8]});
-                dbg("[ZOLT] SHIFT_DEBUG: actual suffix_0_outer[0] = {any}\n", .{suffix_0_outer[0].toBytes()[0..8]});
-
-                // eq+1([r0,r1,...], [0,0,...]) should be 0 (because y=0 is not a successor of any x >= 0)
-                // Actually no, eq+1(x, y) = 1 iff y = x+1
-                // For y=[0,...,0] (binary 0), we need x = -1 which doesn't exist in unsigned
-                // So eq+1(anything, [0,...,0]) = 0
-                dbg("[ZOLT] SHIFT_DEBUG: suffix_1_outer[0] should be ~0: {any}\n", .{suffix_1_outer[0].toBytes()[0..8]});
-
-                // CRITICAL TEST: Evaluate eq+1(r_outer, (r_prefix_be, [0,0,0,0])) directly
-                // and compare with phase2_eq_plus_one_outer[0]
-                //
-                // Construct full y = (r_prefix_be, zeros_4) in big-endian
-                // Wait no, the formula is eq+1(r_outer, (y_hi, y_lo)) where y_lo is bound first.
-                // At index j=0 (all zeros for suffix), y = (zeros_4, r_prefix_be)
-                // So full_y = (zeros_suffix, r_prefix_be) where zeros_suffix has suffix_n_vars zeros
-                const full_y = self.allocator.alloc(F, self.r_outer.len) catch unreachable;
-                defer self.allocator.free(full_y);
-
-                // Big-endian: first half = suffix = zeros (for j=0), second half = prefix = r_prefix_be
-                for (0..self.suffix_n_vars) |i| {
-                    full_y[i] = F.zero();
-                }
-                for (0..r_prefix_be.len) |i| {
-                    full_y[self.suffix_n_vars + i] = r_prefix_be[i];
+                        const val = upc.add(self.gamma_powers[1].mul(pc_val))
+                            .add(self.gamma_powers[2].mul(virt))
+                            .add(self.gamma_powers[3].mul(first));
+                        const term1 = eq_out.mul(val);
+                        const term2 = self.gamma_powers[4].mul(F.one().sub(noop)).mul(eq_prod_v);
+                        phase2_total_sum = phase2_total_sum.add(term1).add(term2);
+                    }
+                    dbg("[ZOLT] SHIFT_PHASE2_VERIFY: phase2_total_sum = {{ {any} }}\n", .{phase2_total_sum.toBytes()});
+                    dbg("[ZOLT] SHIFT_PHASE2_VERIFY: (compare with current_shift_claim at Phase2 start)\n", .{});
                 }
 
-                // Direct evaluation
-                const direct_eq_plus_one = poly_mod.EqPlusOnePolynomial(F).mle(self.r_outer, full_y);
-                dbg("[ZOLT] SHIFT_CRITICAL: direct eq+1(r_outer, (zeros, r_prefix)) = {any}\n", .{direct_eq_plus_one.toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: phase2_eq+1_outer[0] = {any}\n", .{self.phase2_eq_plus_one_outer.?[0].toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: match = {}\n", .{direct_eq_plus_one.eql(self.phase2_eq_plus_one_outer.?[0])});
+                // DEBUG: Verify eq+1_outer initialization by direct evaluation
+                {
+                    // eq+1_outer[0] should equal eq+1(r_outer, (r_prefix_be, [0,0,...,0]))
+                    // where [0,0,...,0] is all zeros (suffix_n_vars zeros)
+                    // This is: prefix_0_eval * suffix_0[0] + prefix_1_eval * suffix_1[0]
 
-                // Debug: check formula components
-                // phase2_eq+1_outer[0] = prefix_0_eval * suffix_0[0] + prefix_1_eval * suffix_1[0]
-                const expected_from_formula = prefix_0_eval_outer.mul(suffix_0_outer[0])
-                    .add(prefix_1_eval_outer.mul(suffix_1_outer[0]));
-                dbg("[ZOLT] SHIFT_CRITICAL: from_formula = {any}\n", .{expected_from_formula.toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: formula_match = {}\n", .{expected_from_formula.eql(self.phase2_eq_plus_one_outer.?[0])});
+                    // First, verify suffix_0[0] = eq(r_outer_hi, [0,...,0])
+                    // eq([r0,r1,...], [0,0,...]) should be prod(1-ri)
+                    var expected_suffix_0_at_0 = F.one();
+                    for (r_outer_hi) |ri| {
+                        expected_suffix_0_at_0 = expected_suffix_0_at_0.mul(F.one().sub(ri));
+                    }
+                    dbg("[ZOLT] SHIFT_DEBUG: expected suffix_0[0] = {any}\n", .{expected_suffix_0_at_0.toBytes()[0..8]});
+                    dbg("[ZOLT] SHIFT_DEBUG: actual suffix_0_outer[0] = {any}\n", .{suffix_0_outer[0].toBytes()[0..8]});
 
-                // Debug: prefix_0 and suffix_0 individually
-                // Direct eq+1(r_lo, y_lo) where y_lo = r_prefix_be
-                const direct_prefix_eval = poly_mod.EqPlusOnePolynomial(F).mle(r_outer_lo, r_prefix_be);
-                dbg("[ZOLT] SHIFT_CRITICAL: direct eq+1(r_lo, y_lo) = {any}\n", .{direct_prefix_eval.toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: prefix_0_eval_outer = {any}\n", .{prefix_0_eval_outer.toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: prefix_match = {}\n", .{direct_prefix_eval.eql(prefix_0_eval_outer)});
+                    // eq+1([r0,r1,...], [0,0,...]) should be 0 (because y=0 is not a successor of any x >= 0)
+                    // Actually no, eq+1(x, y) = 1 iff y = x+1
+                    // For y=[0,...,0] (binary 0), we need x = -1 which doesn't exist in unsigned
+                    // So eq+1(anything, [0,...,0]) = 0
+                    dbg("[ZOLT] SHIFT_DEBUG: suffix_1_outer[0] should be ~0: {any}\n", .{suffix_1_outer[0].toBytes()[0..8]});
 
-                // Direct eq(r_hi, y_hi) where y_hi = zeros
-                const zeros_hi = self.allocator.alloc(F, self.suffix_n_vars) catch unreachable;
-                defer self.allocator.free(zeros_hi);
-                @memset(zeros_hi, F.zero());
-                const direct_suffix_eval = poly_mod.EqPolynomial(F).mle(r_outer_hi, zeros_hi);
-                dbg("[ZOLT] SHIFT_CRITICAL: direct eq(r_hi, zeros) = {any}\n", .{direct_suffix_eval.toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: suffix_0[0] = {any}\n", .{suffix_0_outer[0].toBytes()});
-                dbg("[ZOLT] SHIFT_CRITICAL: suffix_match = {}\n", .{direct_suffix_eval.eql(suffix_0_outer[0])});
+                    // CRITICAL TEST: Evaluate eq+1(r_outer, (r_prefix_be, [0,0,0,0])) directly
+                    // and compare with phase2_eq_plus_one_outer[0]
+                    //
+                    // Construct full y = (r_prefix_be, zeros_4) in big-endian
+                    // Wait no, the formula is eq+1(r_outer, (y_hi, y_lo)) where y_lo is bound first.
+                    // At index j=0 (all zeros for suffix), y = (zeros_4, r_prefix_be)
+                    // So full_y = (zeros_suffix, r_prefix_be) where zeros_suffix has suffix_n_vars zeros
+                    const full_y = self.allocator.alloc(F, self.r_outer.len) catch unreachable;
+                    defer self.allocator.free(full_y);
+
+                    // Big-endian: first half = suffix = zeros (for j=0), second half = prefix = r_prefix_be
+                    for (0..self.suffix_n_vars) |i| {
+                        full_y[i] = F.zero();
+                    }
+                    for (0..r_prefix_be.len) |i| {
+                        full_y[self.suffix_n_vars + i] = r_prefix_be[i];
+                    }
+
+                    // Direct evaluation
+                    const direct_eq_plus_one = poly_mod.EqPlusOnePolynomial(F).mle(self.r_outer, full_y);
+                    dbg("[ZOLT] SHIFT_CRITICAL: direct eq+1(r_outer, (zeros, r_prefix)) = {any}\n", .{direct_eq_plus_one.toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: phase2_eq+1_outer[0] = {any}\n", .{self.phase2_eq_plus_one_outer.?[0].toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: match = {}\n", .{direct_eq_plus_one.eql(self.phase2_eq_plus_one_outer.?[0])});
+
+                    // Debug: check formula components
+                    // phase2_eq+1_outer[0] = prefix_0_eval * suffix_0[0] + prefix_1_eval * suffix_1[0]
+                    const expected_from_formula = prefix_0_eval_outer.mul(suffix_0_outer[0])
+                        .add(prefix_1_eval_outer.mul(suffix_1_outer[0]));
+                    dbg("[ZOLT] SHIFT_CRITICAL: from_formula = {any}\n", .{expected_from_formula.toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: formula_match = {}\n", .{expected_from_formula.eql(self.phase2_eq_plus_one_outer.?[0])});
+
+                    // Debug: prefix_0 and suffix_0 individually
+                    // Direct eq+1(r_lo, y_lo) where y_lo = r_prefix_be
+                    const direct_prefix_eval = poly_mod.EqPlusOnePolynomial(F).mle(r_outer_lo, r_prefix_be);
+                    dbg("[ZOLT] SHIFT_CRITICAL: direct eq+1(r_lo, y_lo) = {any}\n", .{direct_prefix_eval.toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: prefix_0_eval_outer = {any}\n", .{prefix_0_eval_outer.toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: prefix_match = {}\n", .{direct_prefix_eval.eql(prefix_0_eval_outer)});
+
+                    // Direct eq(r_hi, y_hi) where y_hi = zeros
+                    const zeros_hi = self.allocator.alloc(F, self.suffix_n_vars) catch unreachable;
+                    defer self.allocator.free(zeros_hi);
+                    @memset(zeros_hi, F.zero());
+                    const direct_suffix_eval = poly_mod.EqPolynomial(F).mle(r_outer_hi, zeros_hi);
+                    dbg("[ZOLT] SHIFT_CRITICAL: direct eq(r_hi, zeros) = {any}\n", .{direct_suffix_eval.toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: suffix_0[0] = {any}\n", .{suffix_0_outer[0].toBytes()});
+                    dbg("[ZOLT] SHIFT_CRITICAL: suffix_match = {}\n", .{direct_suffix_eval.eql(suffix_0_outer[0])});
+                }
             }
         }
 
@@ -2086,10 +2168,12 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
             const new_size = self.current_witness_size / 2;
 
             // Debug: print current state before binding
-            if (self.current_witness_size <= 16) {
-                dbg("[ZOLT] SHIFT_BIND: size={}, r_j={any}\n", .{ self.current_witness_size, r_j.toBytes()[0..8] });
-                if (self.phase2_eq_plus_one_outer) |eq| {
-                    dbg("[ZOLT] SHIFT_BIND: eq+1_outer[0]={any}, eq+1_outer[1]={any}\n", .{ eq[0].toBytes()[0..8], eq[1].toBytes()[0..8] });
+            if (comptime debug_verbose) {
+                if (self.current_witness_size <= 16) {
+                    dbg("[ZOLT] SHIFT_BIND: size={}, r_j={any}\n", .{ self.current_witness_size, r_j.toBytes()[0..8] });
+                    if (self.phase2_eq_plus_one_outer) |eq| {
+                        dbg("[ZOLT] SHIFT_BIND: eq+1_outer[0]={any}, eq+1_outer[1]={any}\n", .{ eq[0].toBytes()[0..8], eq[1].toBytes()[0..8] });
+                    }
                 }
             }
 
@@ -2100,10 +2184,12 @@ fn ShiftPrefixSuffixProver(comptime F: type) type {
                 self.is_first_in_sequence[i] = self.is_first_in_sequence[2 * i].add(r_j.mul(self.is_first_in_sequence[2 * i + 1].sub(self.is_first_in_sequence[2 * i])));
 
                 // Debug after last binding
-                if (new_size == 1 and self.phase2_eq_plus_one_outer != null) {
-                    const eq = self.phase2_eq_plus_one_outer.?;
-                    const new_val = eq[0].add(r_j.mul(eq[1].sub(eq[0])));
-                    dbg("[ZOLT] SHIFT_BIND_FINAL: new eq+1_outer[0]={any}\n", .{new_val.toBytes()});
+                if (comptime debug_verbose) {
+                    if (new_size == 1 and self.phase2_eq_plus_one_outer != null) {
+                        const eq_dbg = self.phase2_eq_plus_one_outer.?;
+                        const new_val = eq_dbg[0].add(r_j.mul(eq_dbg[1].sub(eq_dbg[0])));
+                        dbg("[ZOLT] SHIFT_BIND_FINAL: new eq+1_outer[0]={any}\n", .{new_val.toBytes()});
+                    }
                 }
                 self.is_noop[i] = self.is_noop[2 * i].add(r_j.mul(self.is_noop[2 * i + 1].sub(self.is_noop[2 * i])));
 
@@ -2594,7 +2680,9 @@ fn RegistersPrefixSuffixProver(comptime F: type) type {
             @memset(Q, F.zero());
 
             // Debug: Print first few R1CS witness values
-            dbg("[STAGE3] RegistersClaimReduction: trace_len={}, prefix_size={}, suffix_size={}, padded_size={}\n", .{ trace_len, prefix_size, suffix_size, padded_size });
+            if (comptime debug_verbose) {
+                dbg("[STAGE3] RegistersClaimReduction: trace_len={}, prefix_size={}, suffix_size={}, padded_size={}\n", .{ trace_len, prefix_size, suffix_size, padded_size });
+            }
 
             for (0..prefix_size) |x_lo| {
                 var q_acc = F.zero();
@@ -2609,36 +2697,38 @@ fn RegistersPrefixSuffixProver(comptime F: type) type {
                     const rs2 = witness[R1CSInputIndex.Rs2Value.toIndex()];
 
                     // Debug: Print first few cycles
-                    if (x < 5) {
-                        // Extract raw u64 values for comparison with Stage 4
-                        const rd_limbs = rd.toBytes();
-                        const rd_u64: u64 = @as(u64, rd_limbs[0]) |
-                            (@as(u64, rd_limbs[1]) << 8) |
-                            (@as(u64, rd_limbs[2]) << 16) |
-                            (@as(u64, rd_limbs[3]) << 24) |
-                            (@as(u64, rd_limbs[4]) << 32) |
-                            (@as(u64, rd_limbs[5]) << 40) |
-                            (@as(u64, rd_limbs[6]) << 48) |
-                            (@as(u64, rd_limbs[7]) << 56);
-                        const rs1_limbs = rs1.toBytes();
-                        const rs1_u64: u64 = @as(u64, rs1_limbs[0]) |
-                            (@as(u64, rs1_limbs[1]) << 8) |
-                            (@as(u64, rs1_limbs[2]) << 16) |
-                            (@as(u64, rs1_limbs[3]) << 24) |
-                            (@as(u64, rs1_limbs[4]) << 32) |
-                            (@as(u64, rs1_limbs[5]) << 40) |
-                            (@as(u64, rs1_limbs[6]) << 48) |
-                            (@as(u64, rs1_limbs[7]) << 56);
-                        const rs2_limbs = rs2.toBytes();
-                        const rs2_u64: u64 = @as(u64, rs2_limbs[0]) |
-                            (@as(u64, rs2_limbs[1]) << 8) |
-                            (@as(u64, rs2_limbs[2]) << 16) |
-                            (@as(u64, rs2_limbs[3]) << 24) |
-                            (@as(u64, rs2_limbs[4]) << 32) |
-                            (@as(u64, rs2_limbs[5]) << 40) |
-                            (@as(u64, rs2_limbs[6]) << 48) |
-                            (@as(u64, rs2_limbs[7]) << 56);
-                        dbg("[STAGE3] Cycle {}: rd_wv={}, rs1_v={}, rs2_v={}\n", .{ x, rd_u64, rs1_u64, rs2_u64 });
+                    if (comptime debug_verbose) {
+                        if (x < 5) {
+                            // Extract raw u64 values for comparison with Stage 4
+                            const rd_limbs = rd.toBytes();
+                            const rd_u64: u64 = @as(u64, rd_limbs[0]) |
+                                (@as(u64, rd_limbs[1]) << 8) |
+                                (@as(u64, rd_limbs[2]) << 16) |
+                                (@as(u64, rd_limbs[3]) << 24) |
+                                (@as(u64, rd_limbs[4]) << 32) |
+                                (@as(u64, rd_limbs[5]) << 40) |
+                                (@as(u64, rd_limbs[6]) << 48) |
+                                (@as(u64, rd_limbs[7]) << 56);
+                            const rs1_limbs = rs1.toBytes();
+                            const rs1_u64: u64 = @as(u64, rs1_limbs[0]) |
+                                (@as(u64, rs1_limbs[1]) << 8) |
+                                (@as(u64, rs1_limbs[2]) << 16) |
+                                (@as(u64, rs1_limbs[3]) << 24) |
+                                (@as(u64, rs1_limbs[4]) << 32) |
+                                (@as(u64, rs1_limbs[5]) << 40) |
+                                (@as(u64, rs1_limbs[6]) << 48) |
+                                (@as(u64, rs1_limbs[7]) << 56);
+                            const rs2_limbs = rs2.toBytes();
+                            const rs2_u64: u64 = @as(u64, rs2_limbs[0]) |
+                                (@as(u64, rs2_limbs[1]) << 8) |
+                                (@as(u64, rs2_limbs[2]) << 16) |
+                                (@as(u64, rs2_limbs[3]) << 24) |
+                                (@as(u64, rs2_limbs[4]) << 32) |
+                                (@as(u64, rs2_limbs[5]) << 40) |
+                                (@as(u64, rs2_limbs[6]) << 48) |
+                                (@as(u64, rs2_limbs[7]) << 56);
+                            dbg("[STAGE3] Cycle {}: rd_wv={}, rs1_v={}, rs2_v={}\n", .{ x, rd_u64, rs1_u64, rs2_u64 });
+                        }
                     }
 
                     // Store witness values

--- a/src/zkvm/spartan/stage5_prover.zig
+++ b/src/zkvm/spartan/stage5_prover.zig
@@ -121,9 +121,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             const gamma = gamma_ram_ra;
             const gamma_raf = gamma_lookups_raf;
 
-            dbg("[STAGE5] Configuration: regs={}, ram_ra={}, lookups={}, max={}\n", .{
-                regs_val_num_rounds, ram_ra_num_rounds, lookups_num_rounds, max_num_rounds,
-            });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Configuration: regs={}, ram_ra={}, lookups={}, max={}\n", .{
+                    regs_val_num_rounds, ram_ra_num_rounds, lookups_num_rounds, max_num_rounds,
+                });
+            }
 
             // Get input claims from accumulator
             const regs_val_input = opening_claims.get(
@@ -164,10 +166,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 .add(gamma_raf.mul(left_op_claim))
                 .add(gamma_raf2.mul(right_op_claim));
 
-            dbg("[STAGE5] Input claims:\n", .{});
-            dbg("  regs_val_input = {any}\n", .{regs_val_input.toBytesBE()[0..8]});
-            dbg("  ram_ra_input = {any}\n", .{ram_ra_input.toBytesBE()[0..8]});
-            dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Input claims:\n", .{});
+                dbg("  regs_val_input = {any}\n", .{regs_val_input.toBytesBE()[0..8]});
+                dbg("  ram_ra_input = {any}\n", .{ram_ra_input.toBytesBE()[0..8]});
+                dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()[0..8]});
+            }
             if (comptime debug_verbose) {
                 const print = std.debug.print;
                 print("[S5 CLAIM DETAIL] rv_claim = {any}\n", .{rv_claim.toBytesBE()});
@@ -189,10 +193,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             const batch1 = transcript.challengeScalarFull(); // coeff for ram_ra
             const batch2 = transcript.challengeScalarFull(); // coeff for regs_val
 
-            dbg("[STAGE5] Batching coefficients (LE for Jolt comparison):\n", .{});
-            dbg("  batch0 (lookups, LE) = {any}\n", .{batch0.toBytes()});
-            dbg("  batch1 (ram_ra, LE) = {any}\n", .{batch1.toBytes()});
-            dbg("  batch2 (regs_val, LE) = {any}\n", .{batch2.toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Batching coefficients (LE for Jolt comparison):\n", .{});
+                dbg("  batch0 (lookups, LE) = {any}\n", .{batch0.toBytes()});
+                dbg("  batch1 (ram_ra, LE) = {any}\n", .{batch1.toBytes()});
+                dbg("  batch2 (regs_val, LE) = {any}\n", .{batch2.toBytes()});
+            }
 
             // Compute scaled input claims
             // Instance i with num_rounds[i] is scaled by 2^(max_num_rounds - num_rounds[i])
@@ -213,7 +219,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 .add(batch1.mul(ram_ra_scaled))
                 .add(batch2.mul(regs_scaled));
 
-            dbg("[STAGE5] Initial batched claim = {any}\n", .{batched_claim.toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Initial batched claim = {any}\n", .{batched_claim.toBytesBE()});
+            }
 
             // Allocate challenges array
             var challenges = try self.allocator.alloc(F, max_num_rounds);
@@ -324,7 +332,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 lookups_claim = lookups_claim.mul(F.fromU64(2).inverse().?);
             }
 
-            dbg("[STAGE5] Final batched claim = {any}\n", .{current_batched_claim.toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Final batched claim = {any}\n", .{current_batched_claim.toBytesBE()});
+            }
 
             // Allocate opening claim arrays
             const num_lookup_tables: usize = 41;
@@ -383,18 +393,22 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             // Use gamma_lookups_raf for Instance 2 (LookupsReadRaf)
             const gamma = gamma_ram_ra; // For RamRaClaimReduction
 
-            dbg("[STAGE5] Configuration with trace: regs={}, ram_ra={}, lookups={}, max={}\n", .{
-                regs_val_num_rounds, ram_ra_num_rounds, lookups_num_rounds, max_num_rounds,
-            });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Configuration with trace: regs={}, ram_ra={}, lookups={}, max={}\n", .{
+                    regs_val_num_rounds, ram_ra_num_rounds, lookups_num_rounds, max_num_rounds,
+                });
+            }
 
             // Debug: print RamRaClaimReduction opening points (use the params to suppress warnings)
-            dbg("[STAGE5] RamRaClaimReduction opening points:\n", .{});
-            dbg("  r_address_raf.len = {}, r_address_rw.len = {}\n", .{ r_address_raf.len, r_address_rw.len });
-            dbg("  r_cycle_raf.len = {}, r_cycle_rw.len = {}, r_cycle_val.len = {}\n", .{
-                r_cycle_raf.len,
-                r_cycle_rw.len,
-                r_cycle_val.len,
-            });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] RamRaClaimReduction opening points:\n", .{});
+                dbg("  r_address_raf.len = {}, r_address_rw.len = {}\n", .{ r_address_raf.len, r_address_rw.len });
+                dbg("  r_cycle_raf.len = {}, r_cycle_rw.len = {}, r_cycle_val.len = {}\n", .{
+                    r_cycle_raf.len,
+                    r_cycle_rw.len,
+                    r_cycle_val.len,
+                });
+            }
 
             // Get input claims from accumulator
             const regs_val_input = opening_claims.get(
@@ -402,9 +416,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             ) orelse F.zero();
 
             // DEBUG: Print the exact value read from opening_claims
-            dbg("[STAGE5 GET] RegistersVal@RegistersReadWriteChecking (trace-aware path):\n", .{});
-            dbg("  LE bytes = {any}\n", .{regs_val_input.toBytes()});
-            dbg("  BE bytes = {any}\n", .{regs_val_input.toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 GET] RegistersVal@RegistersReadWriteChecking (trace-aware path):\n", .{});
+                dbg("  LE bytes = {any}\n", .{regs_val_input.toBytes()});
+                dbg("  BE bytes = {any}\n", .{regs_val_input.toBytesBE()});
+            }
 
             // Upstream RamRaClaimReduction uses 3 claims: raf, rw, val (fused RamValCheck)
             // input_claim = claim_raf + gamma * claim_rw + gamma^2 * claim_val
@@ -425,11 +441,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 .add(gamma2.mul(claim_val));
 
             // Debug: print the three claims that make up ram_ra_input
-            dbg("[STAGE5] RamRaClaimReduction input components:\n", .{});
-            dbg("  claim_raf (RamRafEvaluation) = {any}\n", .{claim_raf.toBytesBE()[16..32].*});
-            dbg("  claim_rw (RamReadWriteChecking) = {any}\n", .{claim_rw.toBytesBE()[16..32].*});
-            dbg("  claim_val (RamValCheck) = {any}\n", .{claim_val.toBytesBE()[16..32].*});
-            dbg("  gamma = {any}\n", .{gamma.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] RamRaClaimReduction input components:\n", .{});
+                dbg("  claim_raf (RamRafEvaluation) = {any}\n", .{claim_raf.toBytesBE()[16..32].*});
+                dbg("  claim_rw (RamReadWriteChecking) = {any}\n", .{claim_rw.toBytesBE()[16..32].*});
+                dbg("  claim_val (RamValCheck) = {any}\n", .{claim_val.toBytesBE()[16..32].*});
+                dbg("  gamma = {any}\n", .{gamma.toBytesBE()[16..32].*});
+            }
 
             // LookupsReadRaf uses gamma_lookups_raf
             const gamma_raf = gamma_lookups_raf;
@@ -450,18 +468,22 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 .add(gamma_raf.mul(left_op_claim))
                 .add(gamma_raf2.mul(right_op_claim));
 
-            dbg("[STAGE5] Input claims (with trace):\n", .{});
-            dbg("  regs_val_input = {any}\n", .{regs_val_input.toBytesBE()});
-            dbg("  ram_ra_input = {any}\n", .{ram_ra_input.toBytesBE()});
-            dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()});
-            dbg("[STAGE5] Transcript state BEFORE appending input claims: {any}\n", .{transcript.state[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Input claims (with trace):\n", .{});
+                dbg("  regs_val_input = {any}\n", .{regs_val_input.toBytesBE()});
+                dbg("  ram_ra_input = {any}\n", .{ram_ra_input.toBytesBE()});
+                dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()});
+                dbg("[STAGE5] Transcript state BEFORE appending input claims: {any}\n", .{transcript.state[0..8]});
+            }
 
             // Append input claims to transcript in VERIFIER instance order:
             // [lookups_read_raf (inst0), ram_ra_reduction (inst1), registers_val_evaluation (inst2)]
             transcript.appendScalar("sumcheck_claim", lookups_input);
             transcript.appendScalar("sumcheck_claim", ram_ra_input);
             transcript.appendScalar("sumcheck_claim", regs_val_input);
-            dbg("[STAGE5] Transcript state AFTER appending input claims: {any}\n", .{transcript.state[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Transcript state AFTER appending input claims: {any}\n", .{transcript.state[0..8]});
+            }
 
             // Squeeze in verifier order: coeff for lookups(inst0), ram_ra(inst1), regs(inst2)
             const batch_coeff_lookups = transcript.challengeScalarFull();
@@ -473,10 +495,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             const batch1 = batch_coeff_ram_ra;
             const batch2 = batch_coeff_lookups;
 
-            dbg("[STAGE5] Batching coefficients:\n", .{});
-            dbg("  batch0 = {x}\n", .{batch0.toBytesBE()[16..32].*});
-            dbg("  batch1 = {x}\n", .{batch1.toBytesBE()[16..32].*});
-            dbg("  batch2 = {x}\n", .{batch2.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Batching coefficients:\n", .{});
+                dbg("  batch0 = {x}\n", .{batch0.toBytesBE()[16..32].*});
+                dbg("  batch1 = {x}\n", .{batch1.toBytesBE()[16..32].*});
+                dbg("  batch2 = {x}\n", .{batch2.toBytesBE()[16..32].*});
+            }
 
             // Build RegistersValEvaluation polynomial tables
             const T = @as(usize, 1) << @intCast(n_cycle_vars);
@@ -490,13 +514,21 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             @memset(wa_evals, F.zero());
 
             // Debug: print r_address and r_cycle from Stage 4
-            dbg("[STAGE5] r_address_regs (len={}):\n", .{r_address_regs.len});
-            for (r_address_regs, 0..) |r, i| {
-                dbg("  r_address[{}] = {any}\n", .{ i, r.toBytesBE()[0..8] });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] r_address_regs (len={}):\n", .{r_address_regs.len});
             }
-            dbg("[STAGE5] r_cycle_regs (len={}):\n", .{r_cycle_regs.len});
+            for (r_address_regs, 0..) |r, i| {
+                if (comptime debug_verbose) {
+                    dbg("  r_address[{}] = {any}\n", .{ i, r.toBytesBE()[0..8] });
+                }
+            }
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] r_cycle_regs (len={}):\n", .{r_cycle_regs.len});
+            }
             for (r_cycle_regs, 0..) |r, i| {
-                dbg("  r_cycle[{}] = {any}\n", .{ i, r.toBytesBE()[0..8] });
+                if (comptime debug_verbose) {
+                    dbg("  r_cycle[{}] = {any}\n", .{ i, r.toBytesBE()[0..8] });
+                }
             }
 
             // Compute LT polynomial using efficient algorithm
@@ -569,20 +601,22 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             buildFullEqTable(r_reduction, lookups_eq_evals[0..T]);
 
             // Debug: print first few eq values and verify sum = 1
-            dbg("[STAGE5 EQ DEBUG] T={}, n_vars={}, First 5 eq_evals:\n", .{ T, n_cycle_vars });
-            var eq_sum = F.zero();
-            var j_idx: usize = 0;
-            while (j_idx < T) : (j_idx += 1) {
-                eq_sum = eq_sum.add(lookups_eq_evals[j_idx]);
-                if (j_idx < 5) {
-                    dbg("  eq_evals[{}] = {x}\n", .{ j_idx, lookups_eq_evals[j_idx].toBytesBE()[16..32].* });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 EQ DEBUG] T={}, n_vars={}, First 5 eq_evals:\n", .{ T, n_cycle_vars });
+                var eq_sum = F.zero();
+                var j_idx: usize = 0;
+                while (j_idx < T) : (j_idx += 1) {
+                    eq_sum = eq_sum.add(lookups_eq_evals[j_idx]);
+                    if (j_idx < 5) {
+                        dbg("  eq_evals[{}] = {x}\n", .{ j_idx, lookups_eq_evals[j_idx].toBytesBE()[16..32].* });
+                    }
                 }
-            }
-            dbg("[STAGE5 EQ DEBUG] Sum of all eq_evals = {x} (should be 1)\n", .{eq_sum.toBytesBE()[16..32].*});
-            dbg("[STAGE5 EQ DEBUG] r_reduction (ALL {} elements, used for eq):\n", .{r_reduction.len});
-            var r_idx: usize = 0;
-            while (r_idx < r_reduction.len) : (r_idx += 1) {
-                dbg("  r_reduction[{}] = {x}\n", .{ r_idx, r_reduction[r_idx].toBytesBE()[16..32].* });
+                dbg("[STAGE5 EQ DEBUG] Sum of all eq_evals = {x} (should be 1)\n", .{eq_sum.toBytesBE()[16..32].*});
+                dbg("[STAGE5 EQ DEBUG] r_reduction (ALL {} elements, used for eq):\n", .{r_reduction.len});
+                var r_idx: usize = 0;
+                while (r_idx < r_reduction.len) : (r_idx += 1) {
+                    dbg("  r_reduction[{}] = {x}\n", .{ r_idx, r_reduction[r_idx].toBytesBE()[16..32].* });
+                }
             }
 
             // Populate inc and wa from trace
@@ -627,17 +661,21 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             }
 
             // Debug: Print first 10 polynomial values
-            dbg("[STAGE5] First 10 polynomial values:\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] First 10 polynomial values:\n", .{});
+            }
             const debug_count = @min(trace_len, 10);
             for (0..debug_count) |j| {
                 const step = trace.steps.items[j];
                 const rd: u8 = step.rd_index;
-                dbg("  j={}: rd={}, pre={}, post={}, inc={x}, wa={x}, lt={x}\n", .{
-                    j, rd, step.rd_pre_value, step.rd_value,
-                    inc_evals[j].toBytesBE()[24..32].*,
-                    wa_evals[j].toBytesBE()[24..32].*,
-                    lt_evals[j].toBytesBE()[24..32].*,
-                });
+                if (comptime debug_verbose) {
+                    dbg("  j={}: rd={}, pre={}, post={}, inc={x}, wa={x}, lt={x}\n", .{
+                        j, rd, step.rd_pre_value, step.rd_value,
+                        inc_evals[j].toBytesBE()[24..32].*,
+                        wa_evals[j].toBytesBE()[24..32].*,
+                        lt_evals[j].toBytesBE()[24..32].*,
+                    });
+                }
             }
 
             // BRUTE FORCE: Compute val(r_address, r_cycle) directly from register state
@@ -1134,9 +1172,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                 // Debug: print first 5 right_op values from combined_vals computation
                 if (j < 5) {
-                    dbg("[STAGE5 COMBINED] j={}: opcode=0x{x}, left_op=0x{x}, right_op=0x{x}, output=0x{x}, table_idx={}\n", .{
-                        j, opcode, left_op.toU64(), right_op.toU64(), lookup_output.toU64(), table_idx,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("[STAGE5 COMBINED] j={}: opcode=0x{x}, left_op=0x{x}, right_op=0x{x}, output=0x{x}, table_idx={}\n", .{
+                            j, opcode, left_op.toU64(), right_op.toU64(), lookup_output.toU64(), table_idx,
+                        });
+                    }
                 }
 
                 // Determine identity path (not interleaved) based on Jolt's flags:
@@ -1340,52 +1380,56 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 // (init_log_t_rounds) using stored_table_values for the cycle rounds.
 
                 // DIAGNOSTIC: Verify lookup_output matches table materializeEntry for each cycle
-                if (table_idx >= 0) {
-                    const t_idx_u: usize = @intCast(table_idx);
-                    const Table = @import("../lookup_table/mod.zig").LookupTable(F, 64);
-                    const table_entry = Table.materializeTableEntry(t_idx_u, lookup_idx);
-                    const table_entry_f = F.fromU64(table_entry);
-                    if (!table_entry_f.eql(lookup_output)) {
-                        dbg("[TABLE MISMATCH] j={}: opcode=0x{x} table={} rd_value=0x{x} table_entry=0x{x} idx=0x{x:0>32}\n", .{
-                            j, opcode, table_idx, lookup_output.toU64(), table_entry, lookup_idx,
-                        });
+                if (comptime debug_verbose) {
+                    if (table_idx >= 0) {
+                        const t_idx_u: usize = @intCast(table_idx);
+                        const Table = @import("../lookup_table/mod.zig").LookupTable(F, 64);
+                        const table_entry = Table.materializeTableEntry(t_idx_u, lookup_idx);
+                        const table_entry_f = F.fromU64(table_entry);
+                        if (!table_entry_f.eql(lookup_output)) {
+                            dbg("[TABLE MISMATCH] j={}: opcode=0x{x} table={} rd_value=0x{x} table_entry=0x{x} idx=0x{x:0>32}\n", .{
+                                j, opcode, table_idx, lookup_output.toU64(), table_entry, lookup_idx,
+                            });
+                        }
                     }
                 }
 
                 // Debug first 5 cycles with full BE bytes
-                if (j < 5) {
-                    dbg("[STAGE5 TRACE DEBUG] j={}: opcode=0x{x}, output={any}, left={any}, right={any}\n", .{
-                        j,
-                        opcode,
-                        lookup_output.toBytesBE()[0..8],
-                        left_op.toBytesBE()[0..8],
-                        right_op.toBytesBE()[0..8],
-                    });
-                    dbg("[STAGE5 INDEX] j={}: is_identity={}, left_raw=0x{x}, right_raw=0x{x}, idx=0x{x:0>32}\n", .{
-                        j, is_identity_path, left_op_raw, right_op_raw, lookup_idx,
-                    });
-                    // Also compute what the OLD interleaved index would have been
-                    const old_idx = interleaveBits128(left_op_raw, right_op_raw);
-                    dbg("[STAGE5 INDEX] j={}: old_interleaved=0x{x:0>32}, changed={}\n", .{
-                        j, old_idx, old_idx != lookup_idx,
-                    });
-                }
-                // Debug first 3 cycles
-                if (j < 3) {
-                    dbg("[STAGE5 LOOKUPS] j={}: opcode=0x{x}, funct3={}, funct7={}, pc=0x{x}\n", .{ j, opcode, funct3, funct7, step.pc });
-                    dbg("  left_op={any}, right_op={any}, output={any}\n", .{
-                        left_op.toBytesBE()[24..32].*,
-                        right_op.toBytesBE()[24..32].*,
-                        lookup_output.toBytesBE()[24..32].*,
-                    });
-                    dbg("  eq={x}, combined={x}\n", .{
-                        lookups_eq_evals[j].toBytesBE()[24..32].*,
-                        lookups_combined_vals[j].toBytesBE()[24..32].*,
-                    });
-                    dbg("  lookup_index: lo=0x{x:0>16}, hi=0x{x:0>16}\n", .{
-                        lookups_indices_lo[j],
-                        lookups_indices_hi[j],
-                    });
+                if (comptime debug_verbose) {
+                    if (j < 5) {
+                        dbg("[STAGE5 TRACE DEBUG] j={}: opcode=0x{x}, output={any}, left={any}, right={any}\n", .{
+                            j,
+                            opcode,
+                            lookup_output.toBytesBE()[0..8],
+                            left_op.toBytesBE()[0..8],
+                            right_op.toBytesBE()[0..8],
+                        });
+                        dbg("[STAGE5 INDEX] j={}: is_identity={}, left_raw=0x{x}, right_raw=0x{x}, idx=0x{x:0>32}\n", .{
+                            j, is_identity_path, left_op_raw, right_op_raw, lookup_idx,
+                        });
+                        // Also compute what the OLD interleaved index would have been
+                        const old_idx = interleaveBits128(left_op_raw, right_op_raw);
+                        dbg("[STAGE5 INDEX] j={}: old_interleaved=0x{x:0>32}, changed={}\n", .{
+                            j, old_idx, old_idx != lookup_idx,
+                        });
+                    }
+                    // Debug first 3 cycles
+                    if (j < 3) {
+                        dbg("[STAGE5 LOOKUPS] j={}: opcode=0x{x}, funct3={}, funct7={}, pc=0x{x}\n", .{ j, opcode, funct3, funct7, step.pc });
+                        dbg("  left_op={any}, right_op={any}, output={any}\n", .{
+                            left_op.toBytesBE()[24..32].*,
+                            right_op.toBytesBE()[24..32].*,
+                            lookup_output.toBytesBE()[24..32].*,
+                        });
+                        dbg("  eq={x}, combined={x}\n", .{
+                            lookups_eq_evals[j].toBytesBE()[24..32].*,
+                            lookups_combined_vals[j].toBytesBE()[24..32].*,
+                        });
+                        dbg("  lookup_index: lo=0x{x:0>16}, hi=0x{x:0>16}\n", .{
+                            lookups_indices_lo[j],
+                            lookups_indices_hi[j],
+                        });
+                    }
                 }
             }
 
@@ -1400,7 +1444,7 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             //   lookups_combined_vals[j] = 0
 
             // Debug: count instructions by opcode to see what we have
-            {
+            if (comptime debug_verbose) {
                 var opcode_counts: [128]u32 = [_]u32{0} ** 128;
                 var identity_count: u32 = 0;
                 var interleaved_count: u32 = 0;
@@ -1410,10 +1454,14 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     opcode_counts[opc] += 1;
                     if (cycle_is_identity_path[j_d]) identity_count += 1 else interleaved_count += 1;
                 }
-                dbg("[STAGE5 OPCODE COUNTS] identity={}, interleaved={}\n", .{identity_count, interleaved_count});
+                if (comptime debug_verbose) {
+                    dbg("[STAGE5 OPCODE COUNTS] identity={}, interleaved={}\n", .{identity_count, interleaved_count});
+                }
                 for (opcode_counts, 0..) |cnt, opc| {
                     if (cnt > 0) {
-                        dbg("  opcode 0x{x:0>2}: {} cycles\n", .{opc, cnt});
+                        if (comptime debug_verbose) {
+                            dbg("  opcode 0x{x:0>2}: {} cycles\n", .{opc, cnt});
+                        }
                     }
                 }
 
@@ -1426,17 +1474,22 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     if (lower64 != step_d.rd_value) {
                         mismatch_count += 1;
                         if (mismatch_count <= 5) {
-                            dbg("[STAGE5 MISMATCH] j={}: opcode=0x{x}, idx_lo=0x{x}, idx_hi=0x{x}, rd_value=0x{x}\n", .{
-                                j_d, step_d.instruction & 0x7f, lower64, lookups_indices_hi[j_d], step_d.rd_value,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 MISMATCH] j={}: opcode=0x{x}, idx_lo=0x{x}, idx_hi=0x{x}, rd_value=0x{x}\n", .{
+                                    j_d, step_d.instruction & 0x7f, lower64, lookups_indices_hi[j_d], step_d.rd_value,
+                                });
+                            }
                         }
                     }
                 }
-                dbg("[STAGE5 MISMATCH] Total table-0 cycles with lower64(idx) != rd_value: {}\n", .{mismatch_count});
+                if (comptime debug_verbose) {
+                    dbg("[STAGE5 MISMATCH] Total table-0 cycles with lower64(idx) != rd_value: {}\n", .{mismatch_count});
+                }
             }
 
             // Verify the sum matches lookups_input
             // Compute individual sums for debugging
+            if (comptime debug_verbose) {
             var output_sum = F.zero();
             var left_sum = F.zero();
             var right_sum = F.zero();
@@ -1687,18 +1740,20 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     const step_dbg2 = trace.steps.items[j];
                     const instr_dbg2 = step_dbg2.instruction;
                     const opcode_dbg2 = instr_dbg2 & 0x7f;
-                    dbg("[COMBINED MISMATCH] j={}: opcode=0x{x}, noop={}, term={}\n", .{
-                        j, opcode_dbg2, step_dbg2.is_noop, step_dbg2.is_termination_store,
-                    });
-                    dbg("  recomputed = {x}\n", .{recomputed_combined.toBytesBE()[16..32].*});
-                    dbg("  combined_v = {x}\n", .{lookups_combined_vals[j].toBytesBE()[16..32].*});
-                    dbg("  recomp: output=0x{x}, left=0x{x}, right=0x{x}\n", .{
-                        lookup_output.toU64(), left_op.toU64(), right_op.toU64(),
-                    });
-                    dbg("  rs1={}, rs2={}, rd={}, pc=0x{x}\n", .{
-                        step_dbg2.rs1_value, step_dbg2.rs2_value,
-                        step_dbg2.rd_value, step_dbg2.pc,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("[COMBINED MISMATCH] j={}: opcode=0x{x}, noop={}, term={}\n", .{
+                            j, opcode_dbg2, step_dbg2.is_noop, step_dbg2.is_termination_store,
+                        });
+                        dbg("  recomputed = {x}\n", .{recomputed_combined.toBytesBE()[16..32].*});
+                        dbg("  combined_v = {x}\n", .{lookups_combined_vals[j].toBytesBE()[16..32].*});
+                        dbg("  recomp: output=0x{x}, left=0x{x}, right=0x{x}\n", .{
+                            lookup_output.toU64(), left_op.toU64(), right_op.toU64(),
+                        });
+                        dbg("  rs1={}, rs2={}, rd={}, pc=0x{x}\n", .{
+                            step_dbg2.rs1_value, step_dbg2.rs2_value,
+                            step_dbg2.rd_value, step_dbg2.pc,
+                        });
+                    }
                     // Also show what table says
                     const tbl_idx_dbg = getLookupTableIndex(opcode_dbg2, @truncate(instr_dbg2 >> 12), @truncate(instr_dbg2 >> 25));
                     if (tbl_idx_dbg >= 0) {
@@ -1708,14 +1763,18 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         const idx_dbg: u128 = @as(u128, hi_dbg) << 64 | @as(u128, lo_dbg);
                         const TableDbg = @import("../lookup_table/mod.zig").LookupTable(F, 64);
                         const tbl_entry_dbg = TableDbg.materializeTableEntry(tbl_u_dbg, idx_dbg);
-                        dbg("  table[{}] at idx=0x{x}: entry=0x{x}\n", .{
-                            tbl_idx_dbg, idx_dbg, tbl_entry_dbg,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("  table[{}] at idx=0x{x}: entry=0x{x}\n", .{
+                                tbl_idx_dbg, idx_dbg, tbl_entry_dbg,
+                            });
+                        }
                     }
                 }
             }
             // Debug: print first 5 cycles' right operand values
-            dbg("[STAGE5 LOOKUPS] First 5 right_op values (computed in loop):\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] First 5 right_op values (computed in loop):\n", .{});
+            }
             for (0..@min(5, trace_len)) |jj| {
                 const step_dbg = trace.steps.items[jj];
                 const instr_dbg = step_dbg.instruction;
@@ -1735,27 +1794,33 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 if (right_is_rs2_dbg) right_input_dbg = F.fromU64(step_dbg.rs2_value);
                 if (right_is_imm_dbg) right_input_dbg = imm_dbg;
 
-                dbg("  j={}: opcode=0x{x}, right_is_rs2={}, right_is_imm={}, imm=0x{x}, rs2=0x{x}, right_input=0x{x}\n", .{
-                    jj, opcode_dbg, right_is_rs2_dbg, right_is_imm_dbg,
-                    imm_dbg.toU64(), step_dbg.rs2_value, right_input_dbg.toU64(),
+                if (comptime debug_verbose) {
+                    dbg("  j={}: opcode=0x{x}, right_is_rs2={}, right_is_imm={}, imm=0x{x}, rs2=0x{x}, right_input=0x{x}\n", .{
+                        jj, opcode_dbg, right_is_rs2_dbg, right_is_imm_dbg,
+                        imm_dbg.toU64(), step_dbg.rs2_value, right_input_dbg.toU64(),
+                    });
+                }
+            }
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] Individual sum verification:\n", .{});
+                dbg("  output_sum (Σ eq*output) = {any}\n", .{output_sum.toBytesBE()[0..16]});
+                dbg("  rv_claim (from Stage 2)  = {any}\n", .{rv_claim.toBytesBE()[0..16]});
+                dbg("  output match = {}\n", .{output_sum.eql(rv_claim)});
+                dbg("  left_sum (Σ eq*left)     = {any}\n", .{left_sum.toBytesBE()[0..16]});
+                dbg("  left_op_claim (Stage 2)  = {any}\n", .{left_op_claim.toBytesBE()[0..16]});
+                dbg("  left match = {}\n", .{left_sum.eql(left_op_claim)});
+                dbg("  right_sum (Σ eq*right)   = {any}\n", .{right_sum.toBytesBE()[0..16]});
+                dbg("  right_op_claim (Stage 2) = {any}\n", .{right_op_claim.toBytesBE()[0..16]});
+                dbg("  right match = {}\n", .{right_sum.eql(right_op_claim)});
+            }
+            // Debug: print first few eq_evals values
+            if (comptime debug_verbose) {
+                dbg("  Stage5 eq_evals[0..3]: {x}, {x}, {x}\n", .{
+                    lookups_eq_evals[0].toBytesBE()[16..32].*,
+                    lookups_eq_evals[1].toBytesBE()[16..32].*,
+                    lookups_eq_evals[2].toBytesBE()[16..32].*,
                 });
             }
-            dbg("[STAGE5 LOOKUPS] Individual sum verification:\n", .{});
-            dbg("  output_sum (Σ eq*output) = {any}\n", .{output_sum.toBytesBE()[0..16]});
-            dbg("  rv_claim (from Stage 2)  = {any}\n", .{rv_claim.toBytesBE()[0..16]});
-            dbg("  output match = {}\n", .{output_sum.eql(rv_claim)});
-            dbg("  left_sum (Σ eq*left)     = {any}\n", .{left_sum.toBytesBE()[0..16]});
-            dbg("  left_op_claim (Stage 2)  = {any}\n", .{left_op_claim.toBytesBE()[0..16]});
-            dbg("  left match = {}\n", .{left_sum.eql(left_op_claim)});
-            dbg("  right_sum (Σ eq*right)   = {any}\n", .{right_sum.toBytesBE()[0..16]});
-            dbg("  right_op_claim (Stage 2) = {any}\n", .{right_op_claim.toBytesBE()[0..16]});
-            dbg("  right match = {}\n", .{right_sum.eql(right_op_claim)});
-            // Debug: print first few eq_evals values
-            dbg("  Stage5 eq_evals[0..3]: {x}, {x}, {x}\n", .{
-                lookups_eq_evals[0].toBytesBE()[16..32].*,
-                lookups_eq_evals[1].toBytesBE()[16..32].*,
-                lookups_eq_evals[2].toBytesBE()[16..32].*,
-            });
             // Verify individual terms
             for (0..5) |jj| {
                 const step_v = trace.steps.items[jj];
@@ -1841,21 +1906,26 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 }
                 const output_v = F.fromU64(step_v.rd_value); // Simplified, ignores JAL/JALR/Branch
 
-                dbg("  [VERIFY j={}] eq={x}, left={x}, right={x}, out={x}\n", .{
-                    jj,
-                    lookups_eq_evals[jj].toBytesBE()[24..32].*,
-                    left_op_v.toBytesBE()[24..32].*,
-                    right_op_v.toBytesBE()[24..32].*,
-                    output_v.toBytesBE()[24..32].*,
-                });
+                if (comptime debug_verbose) {
+                    dbg("  [VERIFY j={}] eq={x}, left={x}, right={x}, out={x}\n", .{
+                        jj,
+                        lookups_eq_evals[jj].toBytesBE()[24..32].*,
+                        left_op_v.toBytesBE()[24..32].*,
+                        right_op_v.toBytesBE()[24..32].*,
+                        output_v.toBytesBE()[24..32].*,
+                    });
+                }
             }
-            dbg("[STAGE5 LOOKUPS] Sum verification:\n", .{});
-            dbg("  computed_sum = {any}\n", .{lookups_computed_sum.toBytesBE()[0..8]});
-            dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()[0..8]});
-            dbg("  rv_claim = {any}\n", .{rv_claim.toBytesBE()[0..8]});
-            dbg("  left_op_claim = {any}\n", .{left_op_claim.toBytesBE()[0..8]});
-            dbg("  right_op_claim = {any}\n", .{right_op_claim.toBytesBE()[0..8]});
-            dbg("  match = {}\n", .{lookups_computed_sum.eql(lookups_input)});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] Sum verification:\n", .{});
+                dbg("  computed_sum = {any}\n", .{lookups_computed_sum.toBytesBE()[0..8]});
+                dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()[0..8]});
+                dbg("  rv_claim = {any}\n", .{rv_claim.toBytesBE()[0..8]});
+                dbg("  left_op_claim = {any}\n", .{left_op_claim.toBytesBE()[0..8]});
+                dbg("  right_op_claim = {any}\n", .{right_op_claim.toBytesBE()[0..8]});
+                dbg("  match = {}\n", .{lookups_computed_sum.eql(lookups_input)});
+            }
+            } // end debug sum verification
 
             // Compute scaling factors
             const regs_scale = max_num_rounds - regs_val_num_rounds;
@@ -1873,8 +1943,10 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 .add(batch1.mul(ram_ra_scaled))
                 .add(batch2.mul(lookups_scaled));
 
-            dbg("[STAGE5] Initial batched claim = {any}\n", .{batched_claim.toBytesBE()});
-            dbg("  [S5P] initial_claim (e before R0): {x}\n", .{batched_claim.toBytes()[0..16].*});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Initial batched claim = {any}\n", .{batched_claim.toBytesBE()});
+                dbg("  [S5P] initial_claim (e before R0): {x}\n", .{batched_claim.toBytes()[0..16].*});
+            }
 
             var challenges = try self.allocator.alloc(F, max_num_rounds);
             errdefer self.allocator.free(challenges);
@@ -1935,7 +2007,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
             // Build sparse RAM access list and precompute G_A, G_B for each access
             const ram_access_count = if (memory_trace) |mt| mt.accesses.items.len else 0;
-            dbg("[STAGE5 RAM_RA] Initializing with {} RAM accesses\n", .{ram_access_count});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 RAM_RA] Initializing with {} RAM accesses\n", .{ram_access_count});
+            }
 
             // Allocate sparse access arrays
             var ram_addresses = try self.allocator.alloc(u64, ram_access_count);
@@ -1982,16 +2056,18 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     ram_G_A[i] = eq_raf_c.add(gamma.mul(eq_val_c));
                     ram_G_B[i] = eq_rw_c.add(gamma.mul(eq_val_c));
 
-                    dbg("[STAGE5 RAM_RA] Access {}: raw_addr=0x{x}, remapped_addr={}, cycle={}\n", .{ i, access.address, remapped_addr, cycle });
-                    dbg("  eq_raf_c={any}, eq_rw_c={any}, eq_val_c={any}\n", .{
-                        eq_raf_c.toBytesBE()[16..32].*,
-                        eq_rw_c.toBytesBE()[16..32].*,
-                        eq_val_c.toBytesBE()[16..32].*,
-                    });
-                    dbg("  G_A={any}, G_B={any}\n", .{
-                        ram_G_A[i].toBytesBE()[16..32].*,
-                        ram_G_B[i].toBytesBE()[16..32].*,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("[STAGE5 RAM_RA] Access {}: raw_addr=0x{x}, remapped_addr={}, cycle={}\n", .{ i, access.address, remapped_addr, cycle });
+                        dbg("  eq_raf_c={any}, eq_rw_c={any}, eq_val_c={any}\n", .{
+                            eq_raf_c.toBytesBE()[16..32].*,
+                            eq_rw_c.toBytesBE()[16..32].*,
+                            eq_val_c.toBytesBE()[16..32].*,
+                        });
+                        dbg("  G_A={any}, G_B={any}\n", .{
+                            ram_G_A[i].toBytesBE()[16..32].*,
+                            ram_G_B[i].toBytesBE()[16..32].*,
+                        });
+                    }
                 }
             }
 
@@ -2010,7 +2086,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 G_A_full[addr_usize] = ram_G_A[i];
                 G_B_full[addr_usize] = ram_G_B[i];
             }
-            dbg("[STAGE5 RAM_RA] Created full-size G_A/G_B arrays (K={}), {} non-zero entries\n", .{ K, ram_access_count });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 RAM_RA] Created full-size G_A/G_B arrays (K={}), {} non-zero entries\n", .{ K, ram_access_count });
+            }
 
             // Initialize B_1 and B_2 polynomials for address rounds
             // B_1 = eq(r_address_raf, k) - this is bound during address rounds
@@ -2029,17 +2107,23 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             }
 
             // Debug: print B_1 and B_2 for first few addresses
-            dbg("[STAGE5 RAM_RA] B_1/B_2 eq polynomials (first 4 and last 4 of {}):\n", .{K});
-            for (0..@min(4, K)) |k| {
-                dbg("  B_1[{}]={any}, B_2[{}]={any}\n", .{
-                    k, B_1[k].toBytesBE()[16..32].*, k, B_2[k].toBytesBE()[16..32].*,
-                });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 RAM_RA] B_1/B_2 eq polynomials (first 4 and last 4 of {}):\n", .{K});
             }
-            if (K > 8) {
-                for (K - 4..K) |k| {
+            for (0..@min(4, K)) |k| {
+                if (comptime debug_verbose) {
                     dbg("  B_1[{}]={any}, B_2[{}]={any}\n", .{
                         k, B_1[k].toBytesBE()[16..32].*, k, B_2[k].toBytesBE()[16..32].*,
                     });
+                }
+            }
+            if (K > 8) {
+                for (K - 4..K) |k| {
+                    if (comptime debug_verbose) {
+                        dbg("  B_1[{}]={any}, B_2[{}]={any}\n", .{
+                            k, B_1[k].toBytesBE()[16..32].*, k, B_2[k].toBytesBE()[16..32].*,
+                        });
+                    }
                 }
             }
 
@@ -2081,32 +2165,38 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     computed_claim_rw = computed_claim_rw.add(B1_at_addr.mul(eq_rw_c));
                     computed_claim_val_eval = computed_claim_val_eval.add(B1_at_addr.mul(eq_val_c));
 
-                    dbg("[STAGE5 COMPUTED CLAIMS] Access {}: addr={}, cycle={}\n", .{ i, addr, cycle });
-                    dbg("  B1_at_addr={x}, B2_at_addr={x}\n", .{
-                        B1_at_addr.toBytesBE()[16..32].*,
-                        B2_at_addr.toBytesBE()[16..32].*,
-                    });
-                    dbg("  eq_raf_c={x}, eq_rw_c={x}, eq_val_c={x}\n", .{
-                        eq_raf_c.toBytesBE()[16..32].*,
-                        eq_rw_c.toBytesBE()[16..32].*,
-                        eq_val_c.toBytesBE()[16..32].*,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("[STAGE5 COMPUTED CLAIMS] Access {}: addr={}, cycle={}\n", .{ i, addr, cycle });
+                        dbg("  B1_at_addr={x}, B2_at_addr={x}\n", .{
+                            B1_at_addr.toBytesBE()[16..32].*,
+                            B2_at_addr.toBytesBE()[16..32].*,
+                        });
+                        dbg("  eq_raf_c={x}, eq_rw_c={x}, eq_val_c={x}\n", .{
+                            eq_raf_c.toBytesBE()[16..32].*,
+                            eq_rw_c.toBytesBE()[16..32].*,
+                            eq_val_c.toBytesBE()[16..32].*,
+                        });
+                    }
                 }
             }
 
-            dbg("[STAGE5] Computed RamRa claims from trace:\n", .{});
-            dbg("  computed_claim_raf = {x}\n", .{computed_claim_raf.toBytesBE()[16..32].*});
-            dbg("  computed_claim_val_final = {x}\n", .{computed_claim_val_final.toBytesBE()[16..32].*});
-            dbg("  computed_claim_rw = {x}\n", .{computed_claim_rw.toBytesBE()[16..32].*});
-            dbg("  computed_claim_val_eval = {x}\n", .{computed_claim_val_eval.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Computed RamRa claims from trace:\n", .{});
+                dbg("  computed_claim_raf = {x}\n", .{computed_claim_raf.toBytesBE()[16..32].*});
+                dbg("  computed_claim_val_final = {x}\n", .{computed_claim_val_final.toBytesBE()[16..32].*});
+                dbg("  computed_claim_rw = {x}\n", .{computed_claim_rw.toBytesBE()[16..32].*});
+                dbg("  computed_claim_val_eval = {x}\n", .{computed_claim_val_eval.toBytesBE()[16..32].*});
+            }
 
             // Recompute ram_ra_input using upstream formula: raf + gamma*rw + gamma^2*val
             const computed_ram_ra_input = computed_claim_raf
                 .add(gamma.mul(computed_claim_rw))
                 .add(gamma2.mul(computed_claim_val_eval));
 
-            dbg("  computed_ram_ra_input = {x}\n", .{computed_ram_ra_input.toBytesBE()[16..32].*});
-            dbg("  original ram_ra_input = {x}\n", .{ram_ra_input.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("  computed_ram_ra_input = {x}\n", .{computed_ram_ra_input.toBytesBE()[16..32].*});
+                dbg("  original ram_ra_input = {x}\n", .{ram_ra_input.toBytesBE()[16..32].*});
+            }
 
             // Initialize Instance 1 claim tracking with SCALED value (matches batched_claim computation)
             // NOTE: We use the ORIGINAL ram_ra_input (from opening_claims), NOT computed_ram_ra_input.
@@ -2115,9 +2205,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             // be adjusted to match the opening_claims, not the other way around.
             ram_ra_current_claim = ram_ra_scaled;
 
-            dbg("[STAGE5] Using original batched claim = {any}\n", .{batched_claim.toBytesBE()});
-            dbg("[STAGE5] computed_ram_ra_input = {x}\n", .{computed_ram_ra_input.toBytesBE()[16..32].*});
-            dbg("[STAGE5] original ram_ra_input = {x}\n", .{ram_ra_input.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Using original batched claim = {any}\n", .{batched_claim.toBytesBE()});
+                dbg("[STAGE5] computed_ram_ra_input = {x}\n", .{computed_ram_ra_input.toBytesBE()[16..32].*});
+                dbg("[STAGE5] original ram_ra_input = {x}\n", .{ram_ra_input.toBytesBE()[16..32].*});
+            }
 
             // Expanding table to track eq(r_addr_reduced_so_far, k_bound_bits)
             // This accumulates the eq value as we bind address bits
@@ -2212,10 +2304,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             const prefix_size = @as(usize, 1) << @intCast(prefix_n_vars);
             const suffix_size = @as(usize, 1) << @intCast(suffix_n_vars);
 
-            dbg("[STAGE5 PQ] PhaseCycle P*Q setup: n_cycle={}, prefix={}, suffix={}\n", .{
-                n_cycle_vars, prefix_n_vars, suffix_n_vars,
-            });
-            dbg("[STAGE5 PQ] prefix_size={}, suffix_size={}\n", .{ prefix_size, suffix_size });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 PQ] PhaseCycle P*Q setup: n_cycle={}, prefix={}, suffix={}\n", .{
+                    n_cycle_vars, prefix_n_vars, suffix_n_vars,
+                });
+                dbg("[STAGE5 PQ] prefix_size={}, suffix_size={}\n", .{ prefix_size, suffix_size });
+            }
 
             // P arrays: eq evaluations for prefix (low) bits
             // P_x[c_lo] = eq(r_cycle_x_lo, c_lo)
@@ -2308,9 +2402,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             }
             // Print first 5 lookup indices (VERIFY FIX APPLIED)
             for (0..@min(5, T)) |j| {
-                dbg("[LOOKUP IDX] j={}: idx=0x{x:0>32}, lo=0x{x:0>16}, hi=0x{x:0>16}\n", .{
-                    j, lookup_indices_u128[j], lookups_indices_lo[j], lookups_indices_hi[j],
-                });
+                if (comptime debug_verbose) {
+                    dbg("[LOOKUP IDX] j={}: idx=0x{x:0>32}, lo=0x{x:0>16}, hi=0x{x:0>16}\n", .{
+                        j, lookup_indices_u128[j], lookups_indices_lo[j], lookups_indices_hi[j],
+                    });
+                }
             }
 
             // Initialize suffix polynomials for phase 0
@@ -2331,11 +2427,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             try suffix_polys.initPhase(0, num_phases, lookups_eq_evals, lookup_indices_u128, cycle_table_indices);
 
             // Debug: count how many cycles have lookup tables assigned
-            var cycles_with_tables: usize = 0;
-            for (0..T) |jj| {
-                if (cycle_table_indices[jj] >= 0) cycles_with_tables += 1;
+            if (comptime debug_verbose) {
+                var cycles_with_tables: usize = 0;
+                for (0..T) |jj| {
+                    if (cycle_table_indices[jj] >= 0) cycles_with_tables += 1;
+                }
+                dbg("[STAGE5] Cycles with lookup tables: {}/{}\n", .{ cycles_with_tables, T });
             }
-            dbg("[STAGE5] Cycles with lookup tables: {}/{}\n", .{ cycles_with_tables, T });
 
             // Initialize RAF (Read-Address-Flag) decompositions for left/right/identity
             // These compute: γ*left + γ²*(identity + right)
@@ -2384,11 +2482,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             // Reset phase 0's expanding table to 1
             expanding_tables[0].reset(F.one());
 
-            dbg("[STAGE5 PREFIX-SUFFIX] Initialized phase 0, log_m={}, suffix_len={}, initial_m={}\n", .{
-                log_m,
-                LOOKUPS_LOG_K - log_m,
-                initial_m,
-            });
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 PREFIX-SUFFIX] Initialized phase 0, log_m={}, suffix_len={}, initial_m={}\n", .{
+                    log_m,
+                    LOOKUPS_LOG_K - log_m,
+                    initial_m,
+                });
+            }
 
             // ==========================================================================
             // DIAGNOSTIC: Verify the total sum from Q polynomials matches brute force
@@ -2405,7 +2505,7 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             //
             // Simpler approach: Compute brute-force rv_claim from trace data and compare
             // ==========================================================================
-            {
+            if (comptime debug_verbose) {
                 // Brute-force: Σ_j u[j] * combined[j] over ALL cycles (not just non-noop)
                 var bf_combined = F.zero();
                 var bf_combined_noop_skipped = F.zero();
@@ -2425,20 +2525,26 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     if (!lookups_combined_vals[jj].eql(F.zero())) nonzero_combined_beyond_trace += 1;
                 }
 
-                dbg("[DIAG INIT] bf_combined (all T={}) = {x}\n", .{ T, bf_combined.toBytesBE()[16..32].* });
-                dbg("[DIAG INIT] bf_combined_noop_skipped = {x}\n", .{bf_combined_noop_skipped.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] combined_all==claim: {}, combined_skip==claim: {}\n", .{ bf_combined.eql(lookups_claim), bf_combined_noop_skipped.eql(lookups_claim) });
-                dbg("[DIAG INIT] nonzero_combined beyond trace: {}\n", .{nonzero_combined_beyond_trace});
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] bf_combined (all T={}) = {x}\n", .{ T, bf_combined.toBytesBE()[16..32].* });
+                    dbg("[DIAG INIT] bf_combined_noop_skipped = {x}\n", .{bf_combined_noop_skipped.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] combined_all==claim: {}, combined_skip==claim: {}\n", .{ bf_combined.eql(lookups_claim), bf_combined_noop_skipped.eql(lookups_claim) });
+                    dbg("[DIAG INIT] nonzero_combined beyond trace: {}\n", .{nonzero_combined_beyond_trace});
+                }
                 // Compare opening claims individually
-                dbg("[DIAG INIT] rv_claim = {x}\n", .{rv_claim.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] left_op_claim = {x}\n", .{left_op_claim.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] right_op_claim = {x}\n", .{right_op_claim.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] gamma_raf = {x}\n", .{gamma_raf.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] gamma_raf2 = {x}\n", .{gamma_raf2.toBytesBE()[16..32].*});
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] rv_claim = {x}\n", .{rv_claim.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] left_op_claim = {x}\n", .{left_op_claim.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] right_op_claim = {x}\n", .{right_op_claim.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] gamma_raf = {x}\n", .{gamma_raf.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] gamma_raf2 = {x}\n", .{gamma_raf2.toBytesBE()[16..32].*});
+                }
                 const recomputed_input = rv_claim.add(gamma_raf.mul(left_op_claim)).add(gamma_raf2.mul(right_op_claim));
-                dbg("[DIAG INIT] recomputed rv+g*l+g2*r = {x}\n", .{recomputed_input.toBytesBE()[16..32].*});
-                dbg("[DIAG INIT] lookups_input match: {}\n", .{recomputed_input.eql(lookups_claim)});
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] recomputed rv+g*l+g2*r = {x}\n", .{recomputed_input.toBytesBE()[16..32].*});
+                    dbg("[DIAG INIT] lookups_input match: {}\n", .{recomputed_input.eql(lookups_claim)});
+                }
 
                 // DIAGNOSTIC: Recompute combined values using R1CS-style formula
                 // and compare against Stage 5's trace-derived combined_vals.
@@ -2589,24 +2695,28 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                         // Compare per-cycle
                         if (!r1cs_combined.eql(lookups_combined_vals[jj_d]) and per_cycle_mismatches < 5) {
-                            dbg("[DIAG MISMATCH] j={}: opcode=0x{x}, funct3={}, funct7={}\n", .{ jj_d, opcode_d, funct3_d, funct7_d });
-                            dbg("  stage5_combined = {x}\n", .{lookups_combined_vals[jj_d].toBytesBE()[16..32].*});
-                            dbg("  r1cs_combined   = {x}\n", .{r1cs_combined.toBytesBE()[16..32].*});
-                            dbg("  stage5_right_op = {x}\n", .{(lookups_combined_vals[jj_d].sub(r1cs_output).sub(gamma_raf.mul(F.zero()))).toBytesBE()[16..32].*});
-                            dbg("  r1cs_right_op   = {x}\n", .{r1cs_right_op.toBytesBE()[16..32].*});
-                            dbg("  rs1={}, rs2={}, imm_field={x}\n", .{
-                                step_d.rs1_value, step_d.rs2_value,
-                                computeImmediate(instr_d).toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[DIAG MISMATCH] j={}: opcode=0x{x}, funct3={}, funct7={}\n", .{ jj_d, opcode_d, funct3_d, funct7_d });
+                                dbg("  stage5_combined = {x}\n", .{lookups_combined_vals[jj_d].toBytesBE()[16..32].*});
+                                dbg("  r1cs_combined   = {x}\n", .{r1cs_combined.toBytesBE()[16..32].*});
+                                dbg("  stage5_right_op = {x}\n", .{(lookups_combined_vals[jj_d].sub(r1cs_output).sub(gamma_raf.mul(F.zero()))).toBytesBE()[16..32].*});
+                                dbg("  r1cs_right_op   = {x}\n", .{r1cs_right_op.toBytesBE()[16..32].*});
+                                dbg("  rs1={}, rs2={}, imm_field={x}\n", .{
+                                    step_d.rs1_value, step_d.rs2_value,
+                                    computeImmediate(instr_d).toBytesBE()[16..32].*,
+                                });
+                            }
                             per_cycle_mismatches += 1;
                         }
                     }
-                    dbg("[DIAG R1CS vs S5] stage5_bf_sum    = {x}\n", .{stage5_bf_sum.toBytesBE()[16..32].*});
-                    dbg("[DIAG R1CS vs S5] r1cs_bf_sum      = {x}\n", .{r1cs_bf_sum.toBytesBE()[16..32].*});
-                    dbg("[DIAG R1CS vs S5] lookups_claim     = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                    dbg("[DIAG R1CS vs S5] stage5 == claim: {}\n", .{stage5_bf_sum.eql(lookups_claim)});
-                    dbg("[DIAG R1CS vs S5] r1cs == claim: {}\n", .{r1cs_bf_sum.eql(lookups_claim)});
-                    dbg("[DIAG R1CS vs S5] per_cycle_mismatches: {}\n", .{per_cycle_mismatches});
+                    if (comptime debug_verbose) {
+                        dbg("[DIAG R1CS vs S5] stage5_bf_sum    = {x}\n", .{stage5_bf_sum.toBytesBE()[16..32].*});
+                        dbg("[DIAG R1CS vs S5] r1cs_bf_sum      = {x}\n", .{r1cs_bf_sum.toBytesBE()[16..32].*});
+                        dbg("[DIAG R1CS vs S5] lookups_claim     = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                        dbg("[DIAG R1CS vs S5] stage5 == claim: {}\n", .{stage5_bf_sum.eql(lookups_claim)});
+                        dbg("[DIAG R1CS vs S5] r1cs == claim: {}\n", .{r1cs_bf_sum.eql(lookups_claim)});
+                        dbg("[DIAG R1CS vs S5] per_cycle_mismatches: {}\n", .{per_cycle_mismatches});
+                    }
                 }
 
                 // Now compute total from Q polynomials directly
@@ -2620,15 +2730,19 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 poly_sum = poly_sum.add(v);
                             }
                             if (!poly_sum.eql(F.zero())) {
-                                dbg("[DIAG INIT] Q_total[table={},suffix={}] = {x}\n", .{
-                                    t_idx, s_idx, poly_sum.toBytesBE()[16..32].*,
-                                });
+                                if (comptime debug_verbose) {
+                                    dbg("[DIAG INIT] Q_total[table={},suffix={}] = {x}\n", .{
+                                        t_idx, s_idx, poly_sum.toBytesBE()[16..32].*,
+                                    });
+                                }
                             }
                             q_total_raw = q_total_raw.add(poly_sum);
                         }
                     }
                 }
-                dbg("[DIAG INIT] Total raw Q sum = {x}\n", .{q_total_raw.toBytesBE()[16..32].*});
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] Total raw Q sum = {x}\n", .{q_total_raw.toBytesBE()[16..32].*});
+                }
 
                 // Also verify: Q[128..255] should be all zero if all addresses have MSB=0
                 var right_half_nonzero: usize = 0;
@@ -2643,7 +2757,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         }
                     }
                 }
-                dbg("[DIAG INIT] Right half (Q[128..255]) non-zero entries: {}\n", .{right_half_nonzero});
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] Right half (Q[128..255]) non-zero entries: {}\n", .{right_half_nonzero});
+                }
 
                 // Also check RAF Q arrays
                 var raf_right_half_nonzero: usize = 0;
@@ -2654,7 +2770,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         if (!identity_raf.Q[qi][idx].eql(F.zero())) raf_right_half_nonzero += 1;
                     }
                 }
-                dbg("[DIAG INIT] RAF right half non-zero entries: {}\n", .{raf_right_half_nonzero});
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] RAF right half non-zero entries: {}\n", .{raf_right_half_nonzero});
+                }
 
                 // Compute total from prefix-suffix at phase 0 (no challenges bound yet)
                 // For each index b (0..255), evaluate the full prefix and combine with Q
@@ -2682,16 +2800,20 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         bf_table0_lookup_output = bf_table0_lookup_output.add(lookups_eq_evals[jj].mul(F.fromU64(lookups_indices_lo[jj])));
                     }
                 }
-                dbg("[DIAG INIT] bf_table0_output (Σu*rd_value for table 0) = {x}\n", .{
-                    bf_table0_output.toBytesBE()[16..32].*,
-                });
-                dbg("[DIAG INIT] bf_table0_lookup (Σu*lookup_lo for table 0) = {x}\n", .{
-                    bf_table0_lookup_output.toBytesBE()[16..32].*,
-                });
+                if (comptime debug_verbose) {
+                    dbg("[DIAG INIT] bf_table0_output (Σu*rd_value for table 0) = {x}\n", .{
+                        bf_table0_output.toBytesBE()[16..32].*,
+                    });
+                    dbg("[DIAG INIT] bf_table0_lookup (Σu*lookup_lo for table 0) = {x}\n", .{
+                        bf_table0_lookup_output.toBytesBE()[16..32].*,
+                    });
+                }
             }
 
             // Run the batched sumcheck
-            dbg("[STAGE5] Entering main sumcheck loop, max_num_rounds={}\n", .{max_num_rounds});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Entering main sumcheck loop, max_num_rounds={}\n", .{max_num_rounds});
+            }
 
             // BRUTE FORCE PER-ROUND DIAGNOSTIC (disabled in release)
             var bf_weights: []F = &[_]F{};
@@ -2741,27 +2863,31 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     const inst0_sum = poly_evals[0].add(poly_evals[1]);
                     const inst0_sum_matches = inst0_sum.eql(regs_val_current_claim);
                     if (round >= LOOKUPS_LOG_K) {
-                        dbg("[INST0 SUMCHECK] Round {}: p(0)+p(1) = {x}, claim0 = {x}, match = {}\n", .{
-                            round,
-                            inst0_sum.toBytesBE()[16..32].*,
-                            regs_val_current_claim.toBytesBE()[16..32].*,
-                            inst0_sum_matches,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[INST0 SUMCHECK] Round {}: p(0)+p(1) = {x}, claim0 = {x}, match = {}\n", .{
+                                round,
+                                inst0_sum.toBytesBE()[16..32].*,
+                                regs_val_current_claim.toBytesBE()[16..32].*,
+                                inst0_sum_matches,
+                            });
+                        }
                     }
 
                     // Debug: Print Instance 0 contribution for cycle rounds
                     if (round >= LOOKUPS_LOG_K and round <= LOOKUPS_LOG_K + 1) {
                         const inst0_coeffs = UniPoly(F).toomCookToCoeffs(poly_evals);
-                        dbg("[ZOLT INST0] Round {}: regs_round={}\n", .{ round, regs_round });
-                        dbg("  poly_evals (Toom) = [{any}, {any}, {any}, {any}]\n", .{
-                            poly_evals[0].toBytes(), poly_evals[1].toBytes(),
-                            poly_evals[2].toBytes(), poly_evals[3].toBytes(),
-                        });
-                        dbg("  inst0_coeffs (coeffs) = [{any}, {any}, {any}, {any}]\n", .{
-                            inst0_coeffs[0].toBytes(), inst0_coeffs[1].toBytes(),
-                            inst0_coeffs[2].toBytes(), inst0_coeffs[3].toBytes(),
-                        });
-                        dbg("  batch0 = {any}\n", .{batch0.toBytes()});
+                        if (comptime debug_verbose) {
+                            dbg("[ZOLT INST0] Round {}: regs_round={}\n", .{ round, regs_round });
+                            dbg("  poly_evals (Toom) = [{any}, {any}, {any}, {any}]\n", .{
+                                poly_evals[0].toBytes(), poly_evals[1].toBytes(),
+                                poly_evals[2].toBytes(), poly_evals[3].toBytes(),
+                            });
+                            dbg("  inst0_coeffs (coeffs) = [{any}, {any}, {any}, {any}]\n", .{
+                                inst0_coeffs[0].toBytes(), inst0_coeffs[1].toBytes(),
+                                inst0_coeffs[2].toBytes(), inst0_coeffs[3].toBytes(),
+                            });
+                            dbg("  batch0 = {any}\n", .{batch0.toBytes()});
+                        }
                     }
                 }
 
@@ -2817,9 +2943,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         if (!phase_cycle_q_initialized) {
                             phase_cycle_q_initialized = true;
 
-                            dbg("[STAGE5 PQ] prefix_n_vars={}, suffix_n_vars={}\n", .{
-                                prefix_n_vars, suffix_n_vars,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 PQ] prefix_n_vars={}, suffix_n_vars={}\n", .{
+                                    prefix_n_vars, suffix_n_vars,
+                                });
+                            }
 
                             // Compute Q arrays: Q_x[c_lo] = Σ_{c_hi} H[c_lo,c_hi] · eq_x_hi(c_hi)
                             // where H[c] = F_values[address[c]] = B_1[address[c]] = eq(r_address, addr)
@@ -2847,7 +2975,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 Q_val[c_lo] = Q_val[c_lo].add(H_c.mul(eq_val_hi[c_hi]));
                             }
 
-                            dbg("[STAGE5 PQ] Q arrays initialized with {} accesses\n", .{ram_access_count});
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 PQ] Q arrays initialized with {} accesses\n", .{ram_access_count});
+                            }
                         }
 
                         // Upstream coefficients: 1, γ, γ² (address pre-evaluated via F_values)
@@ -2866,10 +2996,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             // Then derive eval_0 = claim - eval_1 to guarantee sumcheck property
 
                             // DEBUG: Print claim at start of polynomial computation
-                            dbg("[INST1 HINT DEBUG] Round {}: ram_ra_current_claim at poly start = {x}\n", .{
-                                round,
-                                ram_ra_current_claim.toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[INST1 HINT DEBUG] Round {}: ram_ra_current_claim at poly start = {x}\n", .{
+                                    round,
+                                    ram_ra_current_claim.toBytesBE()[16..32].*,
+                                });
+                            }
 
                             var eval_1 = F.zero();
 
@@ -2922,27 +3054,31 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             inst1_eval_1 = eval_1;
                             inst1_eval_2 = eval_2;
 
-                            dbg("[STAGE5 RAM_RA] PhaseCycle1 round {}: eval_0={x}, eval_1={x}, eval_2={x}\n", .{
-                                cycle_round,
-                                eval_0.toBytesBE()[16..32].*,
-                                eval_1.toBytesBE()[16..32].*,
-                                eval_2.toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 RAM_RA] PhaseCycle1 round {}: eval_0={x}, eval_1={x}, eval_2={x}\n", .{
+                                    cycle_round,
+                                    eval_0.toBytesBE()[16..32].*,
+                                    eval_1.toBytesBE()[16..32].*,
+                                    eval_2.toBytesBE()[16..32].*,
+                                });
+                            }
 
                             // Debug: Print Instance 1 contribution for Round 128-129
                             if (round >= LOOKUPS_LOG_K and round <= LOOKUPS_LOG_K + 1) {
                                 const inst1_evals = [4]F{ eval_0, eval_1, eval_2, F.zero() };
                                 const inst1_coeffs = UniPoly(F).toomCookToCoeffs(inst1_evals);
-                                dbg("[ZOLT INST1] Round {}: ram_ra_round={}, cycle_round={}\n", .{ round, ram_ra_round, cycle_round });
-                                dbg("  inst1_evals (Toom) = [{any}, {any}, {any}, {any}]\n", .{
-                                    inst1_evals[0].toBytes(), inst1_evals[1].toBytes(),
-                                    inst1_evals[2].toBytes(), inst1_evals[3].toBytes(),
-                                });
-                                dbg("  inst1_coeffs (coeffs) = [{any}, {any}, {any}, {any}]\n", .{
-                                    inst1_coeffs[0].toBytes(), inst1_coeffs[1].toBytes(),
-                                    inst1_coeffs[2].toBytes(), inst1_coeffs[3].toBytes(),
-                                });
-                                dbg("  batch1 = {any}\n", .{batch1.toBytes()});
+                                if (comptime debug_verbose) {
+                                    dbg("[ZOLT INST1] Round {}: ram_ra_round={}, cycle_round={}\n", .{ round, ram_ra_round, cycle_round });
+                                    dbg("  inst1_evals (Toom) = [{any}, {any}, {any}, {any}]\n", .{
+                                        inst1_evals[0].toBytes(), inst1_evals[1].toBytes(),
+                                        inst1_evals[2].toBytes(), inst1_evals[3].toBytes(),
+                                    });
+                                    dbg("  inst1_coeffs (coeffs) = [{any}, {any}, {any}, {any}]\n", .{
+                                        inst1_coeffs[0].toBytes(), inst1_coeffs[1].toBytes(),
+                                        inst1_coeffs[2].toBytes(), inst1_coeffs[3].toBytes(),
+                                    });
+                                    dbg("  batch1 = {any}\n", .{batch1.toBytes()});
+                                }
                             }
                         } else {
                             // PhaseCycle2: After prefix rounds, use H' * eq_hi for suffix
@@ -3008,7 +3144,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     scale_val = scale_val.mul(F.one().sub(r_val_j).mul(F.one().sub(chal_j)).add(r_val_j.mul(chal_j)));
                                 }
 
-                                dbg("[STAGE5 RAM_RA] PhaseCycle2 starting at suffix_round={}\n", .{suffix_round});
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 RAM_RA] PhaseCycle2 starting at suffix_round={}\n", .{suffix_round});
+                                }
                             }
 
                             // Compute polynomial using H_prime * eq_hi products
@@ -3071,12 +3209,14 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             inst1_eval_1 = eval_1;
                             inst1_eval_2 = eval_2;
 
-                            dbg("[STAGE5 RAM_RA] PhaseCycle2 round {}: eval_0={x}, eval_1={x}, eval_2={x}\n", .{
-                                cycle_round,
-                                eval_0.toBytesBE()[16..32].*,
-                                eval_1.toBytesBE()[16..32].*,
-                                eval_2.toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 RAM_RA] PhaseCycle2 round {}: eval_0={x}, eval_1={x}, eval_2={x}\n", .{
+                                    cycle_round,
+                                    eval_0.toBytesBE()[16..32].*,
+                                    eval_1.toBytesBE()[16..32].*,
+                                    eval_2.toBytesBE()[16..32].*,
+                                });
+                            }
                         }
                     }
                 }
@@ -3684,11 +3824,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     const poly_sum = combined_poly[0].add(combined_poly[1]);
                     const sumcheck_ok_addr = poly_sum.eql(current_batched_claim);
                     if (!sumcheck_ok_addr) {
-                        dbg("[STAGE5 VERIFY R{}] p(0)+p(1) != claim! p01={x}, claim={x}\n", .{
-                            round,
-                            poly_sum.toBytesBE()[16..32].*,
-                            current_batched_claim.toBytesBE()[16..32].*,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 VERIFY R{}] p(0)+p(1) != claim! p01={x}, claim={x}\n", .{
+                                round,
+                                poly_sum.toBytesBE()[16..32].*,
+                                current_batched_claim.toBytesBE()[16..32].*,
+                            });
+                        }
                     }
 
                     // Compute degree-2 compressed coefficients directly from evaluations
@@ -3706,11 +3848,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     coeffs[1] = batched_c2; // c2
 
                     // Debug: print coefficients in same LE format as Jolt verifier for ALL rounds
-                    dbg("  [S5P] R{} c0={x} c2={x}\n", .{
-                        round,
-                        coeffs[0].toBytes()[0..16].*,
-                        coeffs[1].toBytes()[0..16].*,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("  [S5P] R{} c0={x} c2={x}\n", .{
+                            round,
+                            coeffs[0].toBytes()[0..16].*,
+                            coeffs[1].toBytes()[0..16].*,
+                        });
+                    }
 
                     try proof.compressed_polys.append(self.allocator, .{
                         .coeffs_except_linear_term = coeffs,
@@ -3746,11 +3890,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     current_batched_claim = c0.add(c1.mulHiBigIntU128(challenge.limbs)).add(c2_val.mul(r2));
 
                     // Per-round tracking (matches Jolt verifier's [S5V] output)
-                    dbg("  [S5P] R{} challenge={x} new_e={x} degree=2\n", .{
-                        round,
-                        challenge.toBytes()[0..16].*,
-                        current_batched_claim.toBytes()[0..16].*,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("  [S5P] R{} challenge={x} new_e={x} degree=2\n", .{
+                            round,
+                            challenge.toBytes()[0..16].*,
+                            current_batched_claim.toBytes()[0..16].*,
+                        });
+                    }
 
                     // =====================================================================
                     // CRITICAL FIX: Update lookups_claim to match polynomial evaluation
@@ -3781,18 +3927,20 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: show claim chain for first 3 rounds and last 3 address rounds
                     if (round < 3 or (round >= 125 and round < 128)) {
-                        dbg("[CLAIM_CHAIN R{}] before_claim={x}\n", .{ round, lookups_claim.toBytesBE()[16..32].* });
-                        dbg("[CLAIM_CHAIN R{}] eval_0={x}, eval_1={x}, eval_2={x}\n", .{
-                            round,
-                            eval_0_inst2.toBytesBE()[16..32].*,
-                            eval_1_inst2.toBytesBE()[16..32].*,
-                            eval_2_inst2.toBytesBE()[16..32].*,
-                        });
-                        dbg("[CLAIM_CHAIN R{}] sum_check: eval_0+eval_1={x} (should == before_claim)\n", .{
-                            round,
-                            eval_0_inst2.add(eval_1_inst2).toBytesBE()[16..32].*,
-                        });
-                        dbg("[CLAIM_CHAIN R{}] p(r)={x} -> new_claim\n", .{ round, inst2_at_r.toBytesBE()[16..32].* });
+                        if (comptime debug_verbose) {
+                            dbg("[CLAIM_CHAIN R{}] before_claim={x}\n", .{ round, lookups_claim.toBytesBE()[16..32].* });
+                            dbg("[CLAIM_CHAIN R{}] eval_0={x}, eval_1={x}, eval_2={x}\n", .{
+                                round,
+                                eval_0_inst2.toBytesBE()[16..32].*,
+                                eval_1_inst2.toBytesBE()[16..32].*,
+                                eval_2_inst2.toBytesBE()[16..32].*,
+                            });
+                            dbg("[CLAIM_CHAIN R{}] sum_check: eval_0+eval_1={x} (should == before_claim)\n", .{
+                                round,
+                                eval_0_inst2.add(eval_1_inst2).toBytesBE()[16..32].*,
+                            });
+                            dbg("[CLAIM_CHAIN R{}] p(r)={x} -> new_claim\n", .{ round, inst2_at_r.toBytesBE()[16..32].* });
+                        }
                     }
 
                     // NOTE: lookups_claim will be updated AFTER inst0/inst1 claims,
@@ -3845,23 +3993,27 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     // NOTE: We use (remaining_rounds - 1) because we already computed the polynomial
                     // for this round and are now handling the challenge binding for it
                     if (round >= 126 and round <= 131) {
-                        dbg("[DEBUG BINDING R{}] remaining={}, ram_ra_num_rounds={}, check={}\n", .{
-                            round,
-                            remaining_rounds,
-                            ram_ra_num_rounds,
-                            remaining_rounds <= ram_ra_num_rounds,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[DEBUG BINDING R{}] remaining={}, ram_ra_num_rounds={}, check={}\n", .{
+                                round,
+                                remaining_rounds,
+                                ram_ra_num_rounds,
+                                remaining_rounds <= ram_ra_num_rounds,
+                            });
+                        }
                     }
                     if (remaining_rounds <= ram_ra_num_rounds) {
                         const ram_ra_round = ram_ra_num_rounds - remaining_rounds;
 
                         if (round >= 126 and round <= 130) {
-                            dbg("[DEBUG R{} IN] ram_ra_round={}, log_ram_k={}, is_phase_cycle={}\n", .{
-                                round,
-                                ram_ra_round,
-                                log_ram_k,
-                                ram_ra_round >= log_ram_k,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[DEBUG R{} IN] ram_ra_round={}, log_ram_k={}, is_phase_cycle={}\n", .{
+                                    round,
+                                    ram_ra_round,
+                                    log_ram_k,
+                                    ram_ra_round >= log_ram_k,
+                                });
+                            }
                         }
 
                         {
@@ -3919,16 +4071,20 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 }
 
                                 if (cycle_round < 3) {
-                                    dbg("[STAGE5 RAM_RA] Bound PhaseCycle1 round {}: challenge={x}, new_len={}\n", .{
-                                        cycle_round,
-                                        challenge.toBytesBE()[16..32].*,
-                                        half_len,
-                                    });
-                                    if (half_len > 0) {
-                                        dbg("  P_raf[0]={x}, Q_raf[0]={x}\n", .{
-                                            P_raf[0].toBytesBE()[16..32].*,
-                                            Q_raf[0].toBytesBE()[16..32].*,
+                                    if (comptime debug_verbose) {
+                                        dbg("[STAGE5 RAM_RA] Bound PhaseCycle1 round {}: challenge={x}, new_len={}\n", .{
+                                            cycle_round,
+                                            challenge.toBytesBE()[16..32].*,
+                                            half_len,
                                         });
+                                    }
+                                    if (half_len > 0) {
+                                        if (comptime debug_verbose) {
+                                            dbg("  P_raf[0]={x}, Q_raf[0]={x}\n", .{
+                                                P_raf[0].toBytesBE()[16..32].*,
+                                                Q_raf[0].toBytesBE()[16..32].*,
+                                            });
+                                        }
                                     }
                                 }
                             } else {
@@ -3973,17 +4129,21 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     }
                                 }
 
-                                dbg("[STAGE5 RAM_RA] Bound PhaseCycle2 round {} (suffix {}): challenge={x}, new_len={}\n", .{
-                                    cycle_round,
-                                    suffix_round,
-                                    challenge.toBytesBE()[16..32].*,
-                                    half_len,
-                                });
-                                if (half_len > 0) {
-                                    dbg("  H_prime[0]={x}, eq_raf_hi[0]={x}\n", .{
-                                        H_prime[0].toBytesBE()[16..32].*,
-                                        eq_raf_hi[0].toBytesBE()[16..32].*,
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 RAM_RA] Bound PhaseCycle2 round {} (suffix {}): challenge={x}, new_len={}\n", .{
+                                        cycle_round,
+                                        suffix_round,
+                                        challenge.toBytesBE()[16..32].*,
+                                        half_len,
                                     });
+                                }
+                                if (half_len > 0) {
+                                    if (comptime debug_verbose) {
+                                        dbg("  H_prime[0]={x}, eq_raf_hi[0]={x}\n", .{
+                                            H_prime[0].toBytesBE()[16..32].*,
+                                            eq_raf_hi[0].toBytesBE()[16..32].*,
+                                        });
+                                    }
                                 }
                             }
 
@@ -4001,7 +4161,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     lookups_claim = inst2_at_r;
 
                     // Print Instance 2 claim at EVERY round (matches Jolt's [S5 INST2 CLAIM R{}])
-                    dbg("[S5 INST2 CLAIM R{}] {any}\n", .{ round, lookups_claim.toBytes()[0..16].* });
+                    if (comptime debug_verbose) {
+                        dbg("[S5 INST2 CLAIM R{}] {any}\n", .{ round, lookups_claim.toBytes()[0..16].* });
+                    }
 
                     // BRUTE FORCE CHAIN CHECK (debug only)
                     if (comptime debug_verbose) if (round < 16) {
@@ -4056,16 +4218,18 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print claim tracking for rounds 126-128
                     if (round >= 126 and round <= 128) {
-                        dbg("[ADDR CLAIM TRACK] Round {}: regs_val={x}, ram_ra={x}, lookups={x}\n", .{
-                            round,
-                            regs_val_current_claim.toBytesBE()[16..32].*,
-                            ram_ra_current_claim.toBytesBE()[16..32].*,
-                            lookups_claim.toBytesBE()[16..32].*,
-                        });
-                        dbg("[ADDR CLAIM TRACK] Round {}: batched_claim={x}\n", .{
-                            round,
-                            current_batched_claim.toBytesBE()[16..32].*,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[ADDR CLAIM TRACK] Round {}: regs_val={x}, ram_ra={x}, lookups={x}\n", .{
+                                round,
+                                regs_val_current_claim.toBytesBE()[16..32].*,
+                                ram_ra_current_claim.toBytesBE()[16..32].*,
+                                lookups_claim.toBytesBE()[16..32].*,
+                            });
+                            dbg("[ADDR CLAIM TRACK] Round {}: batched_claim={x}\n", .{
+                                round,
+                                current_batched_claim.toBytesBE()[16..32].*,
+                            });
+                        }
                     }
 
                     // ===================================================================
@@ -4101,7 +4265,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     if ((round + 1) % log_m == 0 and round + 1 < LOOKUPS_LOG_K) {
                         const prev_phase = current_phase;
                         current_phase += 1;
-                        dbg("[STAGE5] Phase transition to phase {}, prev_table_len={}\n", .{ current_phase, expanding_tables[prev_phase].getLen() });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5] Phase transition to phase {}, prev_table_len={}\n", .{ current_phase, expanding_tables[prev_phase].getLen() });
+                        }
 
                         // DRIFT DEBUG BEFORE CONDENSATION:
                         // Verify the expanding table matches direct EQ computation
@@ -4114,9 +4280,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 direct_eq_0 = direct_eq_0.mul(F.one().sub(challenges[prev_phase * log_m + i]));
                             }
                             const table_eq_0 = expanding_tables[prev_phase].get(0);
-                            dbg("[PHASE_VERIFY] expanding_table[0] = {x}\n", .{table_eq_0.toBytesBE()[16..32].*});
-                            dbg("[PHASE_VERIFY] direct_eq(0, r) = {x}\n", .{direct_eq_0.toBytesBE()[16..32].*});
-                            dbg("[PHASE_VERIFY] match = {}\n", .{table_eq_0.eql(direct_eq_0)});
+                            if (comptime debug_verbose) {
+                                dbg("[PHASE_VERIFY] expanding_table[0] = {x}\n", .{table_eq_0.toBytesBE()[16..32].*});
+                                dbg("[PHASE_VERIFY] direct_eq(0, r) = {x}\n", .{direct_eq_0.toBytesBE()[16..32].*});
+                                dbg("[PHASE_VERIFY] match = {}\n", .{table_eq_0.eql(direct_eq_0)});
+                            }
 
                             // Verify entry 1: EQ(1, r) - bit 0 = 1, rest = 0
                             // With HighToLow binding: bit 0 of k corresponds to round (log_m-1) = round 7
@@ -4126,16 +4294,20 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 direct_eq_1 = direct_eq_1.mul(F.one().sub(challenges[prev_phase * log_m + i]));
                             }
                             const table_eq_1 = expanding_tables[prev_phase].get(1);
-                            dbg("[PHASE_VERIFY] expanding_table[1] = {x}\n", .{table_eq_1.toBytesBE()[16..32].*});
-                            dbg("[PHASE_VERIFY] direct_eq(1, r) = {x}\n", .{direct_eq_1.toBytesBE()[16..32].*});
-                            dbg("[PHASE_VERIFY] match = {}\n", .{table_eq_1.eql(direct_eq_1)});
+                            if (comptime debug_verbose) {
+                                dbg("[PHASE_VERIFY] expanding_table[1] = {x}\n", .{table_eq_1.toBytesBE()[16..32].*});
+                                dbg("[PHASE_VERIFY] direct_eq(1, r) = {x}\n", .{direct_eq_1.toBytesBE()[16..32].*});
+                                dbg("[PHASE_VERIFY] match = {}\n", .{table_eq_1.eql(direct_eq_1)});
+                            }
 
                             // Compute brute sum BEFORE condensation (should be original claim)
                             var pre_condense_sum = F.zero();
                             for (0..T) |jj| {
                                 pre_condense_sum = pre_condense_sum.add(lookups_eq_evals[jj].mul(lookups_combined_vals[jj]));
                             }
-                            dbg("[PHASE_VERIFY] pre_condense_sum = {x}\n", .{pre_condense_sum.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[PHASE_VERIFY] pre_condense_sum = {x}\n", .{pre_condense_sum.toBytesBE()[16..32].*});
+                            }
 
                             // Compute "what the condensed sum SHOULD be" by multiplying each term
                             // by the appropriate expanding table entry
@@ -4149,24 +4321,30 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 const v_val = expanding_tables[prev_phase].get(k_bound);
                                 expected_condensed_sum = expected_condensed_sum.add(lookups_eq_evals[jj].mul(v_val).mul(lookups_combined_vals[jj]));
                                 if (jj < 5) {
-                                    dbg("[PHASE_VERIFY] j={}: k_bound={}, v_val={x}, eq={x}, cv={x}\n", .{
-                                        jj, k_bound,
-                                        v_val.toBytesBE()[24..32].*,
-                                        lookups_eq_evals[jj].toBytesBE()[24..32].*,
-                                        lookups_combined_vals[jj].toBytesBE()[24..32].*,
-                                    });
+                                    if (comptime debug_verbose) {
+                                        dbg("[PHASE_VERIFY] j={}: k_bound={}, v_val={x}, eq={x}, cv={x}\n", .{
+                                            jj, k_bound,
+                                            v_val.toBytesBE()[24..32].*,
+                                            lookups_eq_evals[jj].toBytesBE()[24..32].*,
+                                            lookups_combined_vals[jj].toBytesBE()[24..32].*,
+                                        });
+                                    }
                                 }
                             }
-                            dbg("[PHASE_VERIFY] expected_condensed_sum = {x}\n", .{expected_condensed_sum.toBytesBE()[16..32].*});
-                            dbg("[PHASE_VERIFY] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                            dbg("[PHASE_VERIFY] match = {}\n", .{expected_condensed_sum.eql(lookups_claim)});
+                            if (comptime debug_verbose) {
+                                dbg("[PHASE_VERIFY] expected_condensed_sum = {x}\n", .{expected_condensed_sum.toBytesBE()[16..32].*});
+                                dbg("[PHASE_VERIFY] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                                dbg("[PHASE_VERIFY] match = {}\n", .{expected_condensed_sum.eql(lookups_claim)});
+                            }
                         }
 
                         // Condense u_evals (lookups_eq_evals) using the expanding table from the previous phase
                         // This is the CRITICAL step that was missing!
                         // u_evals[j] *= v[prev_phase][k_bound] where k_bound = prefix & m_mask
                         condenseUEvals(F, lookups_eq_evals, &expanding_tables[prev_phase], lookup_indices_u128, current_phase, num_phases);
-                        dbg("[STAGE5] Phase {} condense done, now calling initPhase...\n", .{current_phase});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5] Phase {} condense done, now calling initPhase...\n", .{current_phase});
+                        }
 
                         // DRIFT DEBUG: Compute direct sum after condensation to compare with lookups_claim
                         // At this point, lookups_eq_evals[j] has been condensed to include the expanding table contribution
@@ -4187,7 +4365,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                         // Re-initialize suffix polys and RAF for new phase with condensed u_evals
                         try suffix_polys.initPhase(current_phase, num_phases, lookups_eq_evals, lookup_indices_u128, cycle_table_indices);
-                        dbg("[STAGE5] Phase {} initPhase done, now calling initQRaf...\n", .{current_phase});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5] Phase {} initPhase done, now calling initQRaf...\n", .{current_phase});
+                        }
                         // Save prefix checkpoints before resetting RAF decompositions
                         // After chunk_len rounds, the prefix MLE has been bound down to a single value
                         left_raf.updateCheckpoint();
@@ -4204,12 +4384,16 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         left_raf.initPrefix();
                         right_raf.initPrefix();
                         identity_raf.initPrefix();
-                        dbg("[STAGE5] Phase {} initQRaf + initPrefix done\n", .{current_phase});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5] Phase {} initQRaf + initPrefix done\n", .{current_phase});
+                        }
 
                         // Reset the new phase's expanding table to 1
                         expanding_tables[current_phase].reset(F.one());
 
-                        dbg("[STAGE5] Condensed u_evals with expanding table, reset phase {} table\n", .{current_phase});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5] Condensed u_evals with expanding table, reset phase {} table\n", .{current_phase});
+                        }
                     }
 
                     // Also update legacy ra_weights for cycle rounds (needed for the last 8 rounds)
@@ -4219,29 +4403,35 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print round info for rounds 0-3 and 63-65
                     if (round < 4 or (round >= 63 and round <= 65)) {
-                        dbg("[STAGE5 ADDR] Round {} challenge (full) = {any}\n", .{
-                            round,
-                            challenge.toBytesBE(),
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 ADDR] Round {} challenge (full) = {any}\n", .{
+                                round,
+                                challenge.toBytesBE(),
+                            });
+                        }
                     }
 
                     // Debug: print round info for first round of each chunk
                     if (round % lookups_ra_virtual_log_k_chunk == 0 and (round < 64 or round >= 64)) {
-                        dbg("[STAGE5 RA_CHUNK] Starting chunk {} (rounds {}-{})\n", .{
-                            chunk_idx,
-                            round,
-                            round + lookups_ra_virtual_log_k_chunk - 1,
-                        });
-                        dbg("  bit_index = {} (bit {} of lookup_index)\n", .{ bit_index, bit_index });
-                        dbg("  challenge = {x}\n", .{challenge.toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 RA_CHUNK] Starting chunk {} (rounds {}-{})\n", .{
+                                chunk_idx,
+                                round,
+                                round + lookups_ra_virtual_log_k_chunk - 1,
+                            });
+                            dbg("  bit_index = {} (bit {} of lookup_index)\n", .{ bit_index, bit_index });
+                            dbg("  challenge = {x}\n", .{challenge.toBytesBE()[16..32].*});
+                        }
                         // Print lookup_indices for first 4 cycles
                         for (0..@min(4, T)) |jj| {
                             const idx_lo = lookups_indices_lo[jj];
                             const idx_hi = lookups_indices_hi[jj];
                             const bit_val = getBit128(idx_lo, idx_hi, bit_index);
-                            dbg("  cycle[{}]: lookup_idx=({x:016},{x:016}), bit[{}]={}\n", .{
-                                jj, idx_hi, idx_lo, bit_index, bit_val,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("  cycle[{}]: lookup_idx=({x:016},{x:016}), bit[{}]={}\n", .{
+                                    jj, idx_hi, idx_lo, bit_index, bit_val,
+                                });
+                            }
                         }
                     }
 
@@ -4258,11 +4448,15 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print ra_chunk values after last round of each chunk
                     if ((round + 1) % lookups_ra_virtual_log_k_chunk == 0) {
-                        dbg("[STAGE5 RA_CHUNK] Finished chunk {} after round {}\n", .{ chunk_idx, round });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 RA_CHUNK] Finished chunk {} after round {}\n", .{ chunk_idx, round });
+                        }
                         for (0..@min(4, T)) |jj| {
-                            dbg("  ra_chunk[{}][{}] = {x}\n", .{
-                                chunk_idx, jj, ra_chunk_weights[chunk_idx][jj].toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("  ra_chunk[{}][{}] = {x}\n", .{
+                                    chunk_idx, jj, ra_chunk_weights[chunk_idx][jj].toBytesBE()[16..32].*,
+                                });
+                            }
                         }
                     }
 
@@ -4271,7 +4465,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     // The correct value is p_inst2(r) which we computed earlier.
 
                     if (round % 8 == 7) {
-                        dbg("[STAGE5] Completed rounds 0-{}\n", .{round});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5] Completed rounds 0-{}\n", .{round});
+                        }
                     }
 
                     continue; // Skip the rest of the loop for address rounds
@@ -4308,9 +4504,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         for (0..T) |jj| {
                             pre_remat_sum = pre_remat_sum.add(lookups_eq_evals[jj].mul(lookups_combined_vals[jj]));
                         }
-                        dbg("[PRE-REMAT] sum(eq*combined_vals) = {x}\n", .{pre_remat_sum.toBytesBE()[16..32].*});
-                        dbg("[PRE-REMAT] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                        dbg("[PRE-REMAT] match = {}\n", .{pre_remat_sum.eql(lookups_claim)});
+                        if (comptime debug_verbose) {
+                            dbg("[PRE-REMAT] sum(eq*combined_vals) = {x}\n", .{pre_remat_sum.toBytesBE()[16..32].*});
+                            dbg("[PRE-REMAT] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            dbg("[PRE-REMAT] match = {}\n", .{pre_remat_sum.eql(lookups_claim)});
+                        }
 
                         // Get bound prefix values from RAF decompositions
                         // After 128 address rounds, the prefix MLE has been bound to a single value.
@@ -4383,36 +4581,44 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             computed_right = computed_right.add(r_right.mul(two_power));
                         }
 
-                        dbg("[STAGE5 REMATERIALIZE] Verification:\n", .{});
-                        dbg("  computed_identity (from challenges) = {x}\n", .{computed_identity.toBytesBE()[16..32].*});
-                        dbg("  identity_prefix (from bound_value) = {x}\n", .{identity_prefix.toBytesBE()[16..32].*});
-                        dbg("  identity match = {}\n", .{computed_identity.eql(identity_prefix)});
-                        dbg("  computed_left (from challenges) = {x}\n", .{computed_left.toBytesBE()[16..32].*});
-                        dbg("  left_prefix (from bound_value) = {x}\n", .{left_prefix.toBytesBE()[16..32].*});
-                        dbg("  left match = {}\n", .{computed_left.eql(left_prefix)});
-                        dbg("  computed_right (from challenges) = {x}\n", .{computed_right.toBytesBE()[16..32].*});
-                        dbg("  right_prefix (from bound_value) = {x}\n", .{right_prefix.toBytesBE()[16..32].*});
-                        dbg("  right match = {}\n", .{computed_right.eql(right_prefix)});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 REMATERIALIZE] Verification:\n", .{});
+                            dbg("  computed_identity (from challenges) = {x}\n", .{computed_identity.toBytesBE()[16..32].*});
+                            dbg("  identity_prefix (from bound_value) = {x}\n", .{identity_prefix.toBytesBE()[16..32].*});
+                            dbg("  identity match = {}\n", .{computed_identity.eql(identity_prefix)});
+                            dbg("  computed_left (from challenges) = {x}\n", .{computed_left.toBytesBE()[16..32].*});
+                            dbg("  left_prefix (from bound_value) = {x}\n", .{left_prefix.toBytesBE()[16..32].*});
+                            dbg("  left match = {}\n", .{computed_left.eql(left_prefix)});
+                            dbg("  computed_right (from challenges) = {x}\n", .{computed_right.toBytesBE()[16..32].*});
+                            dbg("  right_prefix (from bound_value) = {x}\n", .{right_prefix.toBytesBE()[16..32].*});
+                            dbg("  right match = {}\n", .{computed_right.eql(right_prefix)});
+                        }
 
                         // Print first few challenges to compare with Jolt
-                        dbg("  First 4 challenges (to compare with Jolt):\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("  First 4 challenges (to compare with Jolt):\n", .{});
+                        }
                         for (0..4) |i| {
-                            dbg("    challenges[{}] = {x}\n", .{ i, challenges[i].toBytesBE()[16..32].* });
+                            if (comptime debug_verbose) {
+                                dbg("    challenges[{}] = {x}\n", .{ i, challenges[i].toBytesBE()[16..32].* });
+                            }
                         }
 
                         // Compute RAF scalar values
                         const raf_interleaved = gamma_raf.mul(left_prefix).add(gamma_raf2.mul(right_prefix));
                         const raf_identity = gamma_raf2.mul(identity_prefix);
 
-                        dbg("[STAGE5 REMATERIALIZE] round=128, left_prefix={x}, right_prefix={x}, identity_prefix={x}\n", .{
-                            left_prefix.toBytesBE()[16..32].*,
-                            right_prefix.toBytesBE()[16..32].*,
-                            identity_prefix.toBytesBE()[16..32].*,
-                        });
-                        dbg("[STAGE5 REMATERIALIZE] raf_interleaved={x}, raf_identity={x}\n", .{
-                            raf_interleaved.toBytesBE()[16..32].*,
-                            raf_identity.toBytesBE()[16..32].*,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 REMATERIALIZE] round=128, left_prefix={x}, right_prefix={x}, identity_prefix={x}\n", .{
+                                left_prefix.toBytesBE()[16..32].*,
+                                right_prefix.toBytesBE()[16..32].*,
+                                identity_prefix.toBytesBE()[16..32].*,
+                            });
+                            dbg("[STAGE5 REMATERIALIZE] raf_interleaved={x}, raf_identity={x}\n", .{
+                                raf_interleaved.toBytesBE()[16..32].*,
+                                raf_identity.toBytesBE()[16..32].*,
+                            });
+                        }
 
                         // ============================================================
                         // CRITICAL FIX: Use table MLE at r_address, NOT raw lookup output
@@ -4471,8 +4677,10 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                             lookups_combined_vals[j] = val;
                         }
-                        dbg("[STAGE5 REMAT] combined_vals rematerialized for {} cycles\n", .{T});
-                        dbg("[STAGE5 REMAT] combined_vals[0] = {x}\n", .{lookups_combined_vals[0].toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 REMAT] combined_vals rematerialized for {} cycles\n", .{T});
+                            dbg("[STAGE5 REMAT] combined_vals[0] = {x}\n", .{lookups_combined_vals[0].toBytesBE()[16..32].*});
+                        }
 
                         // ============================================================
                         // DEBUG: Direct MLE computation for comparison
@@ -4485,20 +4693,28 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         //   Σ_{i=0}^{63} 2^(63-i) * r[64+i]
                         //
                         // This means: r_address_prime[64] has coeff 2^63, r[65] has 2^62, etc.
-                        dbg("[STAGE5 DEBUG] Direct MLE computation for RangeCheck:\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 DEBUG] Direct MLE computation for RangeCheck:\n", .{});
+                        }
                         // Debug: print challenges[64], [65], and [127] for comparison with Jolt (FULL 32 bytes)
                         const ch64_bytes = challenges[64].toBytesBE();
-                        dbg("[STAGE5 DEBUG] challenges[64] (FULL 32) = ", .{});
-                        for (ch64_bytes) |b| dbg("{x:0>2}", .{b});
-                        dbg("\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 DEBUG] challenges[64] (FULL 32) = ", .{});
+                            for (ch64_bytes) |b| dbg("{x:0>2}", .{b});
+                            dbg("\n", .{});
+                        }
                         const ch65_bytes = challenges[65].toBytesBE();
-                        dbg("[STAGE5 DEBUG] challenges[65] (FULL 32) = ", .{});
-                        for (ch65_bytes) |b| dbg("{x:0>2}", .{b});
-                        dbg("\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 DEBUG] challenges[65] (FULL 32) = ", .{});
+                            for (ch65_bytes) |b| dbg("{x:0>2}", .{b});
+                            dbg("\n", .{});
+                        }
                         const ch127_bytes = challenges[127].toBytesBE();
-                        dbg("[STAGE5 DEBUG] challenges[127] (FULL 32) = ", .{});
-                        for (ch127_bytes) |b| dbg("{x:0>2}", .{b});
-                        dbg("\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 DEBUG] challenges[127] (FULL 32) = ", .{});
+                            for (ch127_bytes) |b| dbg("{x:0>2}", .{b});
+                            dbg("\n", .{});
+                        }
                         var direct_range_check_mle = F.zero();
                         for (0..64) |i| {
                             // challenges are in HighToLow order: challenge[0] binds bit 127
@@ -4509,20 +4725,24 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             const coeff = if (shift < 64) F.fromU64(@as(u64, 1) << @intCast(shift)) else F.zero();
                             direct_range_check_mle = direct_range_check_mle.add(coeff.mul(r_i));
                             if (i < 3 or i >= 61) {
-                                dbg("  i={}, shift={}, coeff=2^{}, r={x}\n", .{
-                                    i, shift, shift, r_i.toBytesBE()[28..32].*,
-                                });
+                                if (comptime debug_verbose) {
+                                    dbg("  i={}, shift={}, coeff=2^{}, r={x}\n", .{
+                                        i, shift, shift, r_i.toBytesBE()[28..32].*,
+                                    });
+                                }
                             }
                         }
-                        dbg("[STAGE5 DEBUG] Direct RangeCheck MLE result: {x}\n", .{
-                            direct_range_check_mle.toBytesBE()[16..32].*,
-                        });
-                        dbg("[STAGE5 DEBUG] Prefix-suffix result (table[0]): {x}\n", .{
-                            table_values[0].toBytesBE()[16..32].*,
-                        });
-                        dbg("[STAGE5 DEBUG] Match: {}\n", .{
-                            direct_range_check_mle.eql(table_values[0]),
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 DEBUG] Direct RangeCheck MLE result: {x}\n", .{
+                                direct_range_check_mle.toBytesBE()[16..32].*,
+                            });
+                            dbg("[STAGE5 DEBUG] Prefix-suffix result (table[0]): {x}\n", .{
+                                table_values[0].toBytesBE()[16..32].*,
+                            });
+                            dbg("[STAGE5 DEBUG] Match: {}\n", .{
+                                direct_range_check_mle.eql(table_values[0]),
+                            });
+                        }
 
                         // Verify AND table (index 2): Σ 2^(63-i) * r[2*i] * r[2*i+1]
                         var direct_and_mle = F.zero();
@@ -4532,9 +4752,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             const shift_and: u6 = @intCast(63 - i);
                             direct_and_mle = direct_and_mle.add(F.fromU64(@as(u64, 1) << shift_and).mul(x_i.mul(y_i)));
                         }
-                        dbg("[TABLE_VERIFY] AND direct = {x}\n", .{direct_and_mle.toBytesBE()[16..32].*});
-                        dbg("[TABLE_VERIFY] AND prefix-suffix = {x}\n", .{table_values[2].toBytesBE()[16..32].*});
-                        dbg("[TABLE_VERIFY] AND match: {}\n", .{direct_and_mle.eql(table_values[2])});
+                        if (comptime debug_verbose) {
+                            dbg("[TABLE_VERIFY] AND direct = {x}\n", .{direct_and_mle.toBytesBE()[16..32].*});
+                            dbg("[TABLE_VERIFY] AND prefix-suffix = {x}\n", .{table_values[2].toBytesBE()[16..32].*});
+                            dbg("[TABLE_VERIFY] AND match: {}\n", .{direct_and_mle.eql(table_values[2])});
+                        }
 
                         // Verify XOR table (index 5): Σ 2^(63-i) * ((1-x)*y + x*(1-y))
                         var direct_xor_mle = F.zero();
@@ -4545,9 +4767,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             const xor_val = F.one().sub(x_i).mul(y_i).add(x_i.mul(F.one().sub(y_i)));
                             direct_xor_mle = direct_xor_mle.add(F.fromU64(@as(u64, 1) << shift_xor).mul(xor_val));
                         }
-                        dbg("[TABLE_VERIFY] XOR direct = {x}\n", .{direct_xor_mle.toBytesBE()[16..32].*});
-                        dbg("[TABLE_VERIFY] XOR prefix-suffix = {x}\n", .{table_values[5].toBytesBE()[16..32].*});
-                        dbg("[TABLE_VERIFY] XOR match: {}\n", .{direct_xor_mle.eql(table_values[5])});
+                        if (comptime debug_verbose) {
+                            dbg("[TABLE_VERIFY] XOR direct = {x}\n", .{direct_xor_mle.toBytesBE()[16..32].*});
+                            dbg("[TABLE_VERIFY] XOR prefix-suffix = {x}\n", .{table_values[5].toBytesBE()[16..32].*});
+                            dbg("[TABLE_VERIFY] XOR match: {}\n", .{direct_xor_mle.eql(table_values[5])});
+                        }
 
                         // Verify OR table (index 4): Σ 2^(63-i) * (x + y - x*y)
                         var direct_or_mle = F.zero();
@@ -4558,9 +4782,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             const or_val = x_i.add(y_i).sub(x_i.mul(y_i));
                             direct_or_mle = direct_or_mle.add(F.fromU64(@as(u64, 1) << shift_or).mul(or_val));
                         }
-                        dbg("[TABLE_VERIFY] OR direct = {x}\n", .{direct_or_mle.toBytesBE()[16..32].*});
-                        dbg("[TABLE_VERIFY] OR prefix-suffix = {x}\n", .{table_values[4].toBytesBE()[16..32].*});
-                        dbg("[TABLE_VERIFY] OR match: {}\n", .{direct_or_mle.eql(table_values[4])});
+                        if (comptime debug_verbose) {
+                            dbg("[TABLE_VERIFY] OR direct = {x}\n", .{direct_or_mle.toBytesBE()[16..32].*});
+                            dbg("[TABLE_VERIFY] OR prefix-suffix = {x}\n", .{table_values[4].toBytesBE()[16..32].*});
+                            dbg("[TABLE_VERIFY] OR match: {}\n", .{direct_or_mle.eql(table_values[4])});
+                        }
 
                         // Verify UnsignedLessThan table (index 11):
                         // Σ_i (1 - r[2*i]) * r[2*i+1] * Π_{j<i} (r[2*j]*r[2*j+1] + (1-r[2*j])*(1-r[2*j+1]))
@@ -4573,11 +4799,15 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 direct_ult_mle = direct_ult_mle.add(F.one().sub(x_i).mul(y_i).mul(eq_term));
                                 eq_term = eq_term.mul(x_i.mul(y_i).add(F.one().sub(x_i).mul(F.one().sub(y_i))));
                             }
-                            dbg("[TABLE_VERIFY] UnsignedLessThan direct = {any}\n", .{direct_ult_mle.toBytes()});
-                            dbg("[TABLE_VERIFY] UnsignedLessThan prefix-suffix = {any}\n", .{table_values[11].toBytes()});
-                            dbg("[TABLE_VERIFY] UnsignedLessThan match: {}\n", .{direct_ult_mle.eql(table_values[11])});
+                            if (comptime debug_verbose) {
+                                dbg("[TABLE_VERIFY] UnsignedLessThan direct = {any}\n", .{direct_ult_mle.toBytes()});
+                                dbg("[TABLE_VERIFY] UnsignedLessThan prefix-suffix = {any}\n", .{table_values[11].toBytes()});
+                                dbg("[TABLE_VERIFY] UnsignedLessThan match: {}\n", .{direct_ult_mle.eql(table_values[11])});
+                            }
                             // Also compare with Jolt's expected value
-                            dbg("[TABLE_VERIFY] UnsignedLessThan Jolt val = ce b8 26 7f 68 99 84 22 e1 c6 cd a7 b2 dd cd 24 a4 7a 39 dc 1f 7f f9 d7 7f 51 3f 23 03 54 5f 1c\n", .{});
+                            if (comptime debug_verbose) {
+                                dbg("[TABLE_VERIFY] UnsignedLessThan Jolt val = ce b8 26 7f 68 99 84 22 e1 c6 cd a7 b2 dd cd 24 a4 7a 39 dc 1f 7f f9 d7 7f 51 3f 23 03 54 5f 1c\n", .{});
+                            }
                         }
 
                         // Verify Equal table (index 6): Π (x_i*y_i + (1-x_i)*(1-y_i))
@@ -4589,9 +4819,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 const eq_term = x_i.mul(y_i).add(F.one().sub(x_i).mul(F.one().sub(y_i)));
                                 direct_equal_mle = direct_equal_mle.mul(eq_term);
                             }
-                            dbg("[TABLE_VERIFY] Equal direct = {any}\n", .{direct_equal_mle.toBytes()});
-                            dbg("[TABLE_VERIFY] Equal prefix-suffix = {any}\n", .{table_values[6].toBytes()});
-                            dbg("[TABLE_VERIFY] Equal match: {}\n", .{direct_equal_mle.eql(table_values[6])});
+                            if (comptime debug_verbose) {
+                                dbg("[TABLE_VERIFY] Equal direct = {any}\n", .{direct_equal_mle.toBytes()});
+                                dbg("[TABLE_VERIFY] Equal prefix-suffix = {any}\n", .{table_values[6].toBytes()});
+                                dbg("[TABLE_VERIFY] Equal match: {}\n", .{direct_equal_mle.eql(table_values[6])});
+                            }
                         }
 
                         // Verify UnsignedGTE table (index 8): 1 - ULT
@@ -4605,9 +4837,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 eq_term = eq_term.mul(x_i.mul(y_i).add(F.one().sub(x_i).mul(F.one().sub(y_i))));
                             }
                             const direct_ugte_mle = F.one().sub(direct_ult);
-                            dbg("[TABLE_VERIFY] UnsignedGTE direct = {any}\n", .{direct_ugte_mle.toBytes()});
-                            dbg("[TABLE_VERIFY] UnsignedGTE prefix-suffix = {any}\n", .{table_values[8].toBytes()});
-                            dbg("[TABLE_VERIFY] UnsignedGTE match: {}\n", .{direct_ugte_mle.eql(table_values[8])});
+                            if (comptime debug_verbose) {
+                                dbg("[TABLE_VERIFY] UnsignedGTE direct = {any}\n", .{direct_ugte_mle.toBytes()});
+                                dbg("[TABLE_VERIFY] UnsignedGTE prefix-suffix = {any}\n", .{table_values[8].toBytes()});
+                                dbg("[TABLE_VERIFY] UnsignedGTE match: {}\n", .{direct_ugte_mle.eql(table_values[8])});
+                            }
                         }
 
                         // Verify ValidUnsignedRemainder table (index 16): LT + divisor_is_zero
@@ -4623,9 +4857,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 eq_term = eq_term.mul(x_i.mul(y_i).add(F.one().sub(x_i).mul(F.one().sub(y_i))));
                             }
                             const direct_vur_mle = lt.add(divisor_is_zero);
-                            dbg("[TABLE_VERIFY] ValidUnsignedRemainder direct = {any}\n", .{direct_vur_mle.toBytes()});
-                            dbg("[TABLE_VERIFY] ValidUnsignedRemainder prefix-suffix = {any}\n", .{table_values[16].toBytes()});
-                            dbg("[TABLE_VERIFY] ValidUnsignedRemainder match: {}\n", .{direct_vur_mle.eql(table_values[16])});
+                            if (comptime debug_verbose) {
+                                dbg("[TABLE_VERIFY] ValidUnsignedRemainder direct = {any}\n", .{direct_vur_mle.toBytes()});
+                                dbg("[TABLE_VERIFY] ValidUnsignedRemainder prefix-suffix = {any}\n", .{table_values[16].toBytes()});
+                                dbg("[TABLE_VERIFY] ValidUnsignedRemainder match: {}\n", .{direct_vur_mle.eql(table_values[16])});
+                            }
                         }
 
                         // Verify NotEqual table (index 9): 1 - Equal
@@ -4637,43 +4873,67 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 direct_eq = direct_eq.mul(x_i.mul(y_i).add(F.one().sub(x_i).mul(F.one().sub(y_i))));
                             }
                             const direct_neq_mle = F.one().sub(direct_eq);
-                            dbg("[TABLE_VERIFY] NotEqual direct = {any}\n", .{direct_neq_mle.toBytes()});
-                            dbg("[TABLE_VERIFY] NotEqual prefix-suffix = {any}\n", .{table_values[9].toBytes()});
-                            dbg("[TABLE_VERIFY] NotEqual match: {}\n", .{direct_neq_mle.eql(table_values[9])});
+                            if (comptime debug_verbose) {
+                                dbg("[TABLE_VERIFY] NotEqual direct = {any}\n", .{direct_neq_mle.toBytes()});
+                                dbg("[TABLE_VERIFY] NotEqual prefix-suffix = {any}\n", .{table_values[9].toBytes()});
+                                dbg("[TABLE_VERIFY] NotEqual match: {}\n", .{direct_neq_mle.eql(table_values[9])});
+                            }
                         }
 
                         // Debug: print key prefix checkpoint values
-                        dbg("[STAGE5 REMATERIALIZE] Key prefix checkpoints:\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 REMATERIALIZE] Key prefix checkpoints:\n", .{});
+                        }
                         const lw_idx = @intFromEnum(lookup_table_mod.Prefixes.LowerWord);
                         const eq_idx = @intFromEnum(lookup_table_mod.Prefixes.Eq);
                         const lt_idx = @intFromEnum(lookup_table_mod.Prefixes.LessThan);
                         const lsb_idx = @intFromEnum(lookup_table_mod.Prefixes.Lsb);
                         if (prefix_checkpoints.checkpoints[lw_idx]) |v| {
-                            dbg("  LowerWord = {x}\n", .{v.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("  LowerWord = {x}\n", .{v.toBytesBE()[16..32].*});
+                            }
                         } else {
-                            dbg("  LowerWord = NULL\n", .{});
+                            if (comptime debug_verbose) {
+                                dbg("  LowerWord = NULL\n", .{});
+                            }
                         }
                         if (prefix_checkpoints.checkpoints[eq_idx]) |v| {
-                            dbg("  Eq = {x}\n", .{v.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("  Eq = {x}\n", .{v.toBytesBE()[16..32].*});
+                            }
                         } else {
-                            dbg("  Eq = NULL\n", .{});
+                            if (comptime debug_verbose) {
+                                dbg("  Eq = NULL\n", .{});
+                            }
                         }
                         if (prefix_checkpoints.checkpoints[lt_idx]) |v| {
-                            dbg("  LessThan = {x}\n", .{v.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("  LessThan = {x}\n", .{v.toBytesBE()[16..32].*});
+                            }
                         } else {
-                            dbg("  LessThan = NULL\n", .{});
+                            if (comptime debug_verbose) {
+                                dbg("  LessThan = NULL\n", .{});
+                            }
                         }
                         if (prefix_checkpoints.checkpoints[lsb_idx]) |v| {
-                            dbg("  Lsb = {x}\n", .{v.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("  Lsb = {x}\n", .{v.toBytesBE()[16..32].*});
+                            }
                         } else {
-                            dbg("  Lsb = NULL\n", .{});
+                            if (comptime debug_verbose) {
+                                dbg("  Lsb = NULL\n", .{});
+                            }
                         }
 
                         // Debug: print table values
-                        dbg("[STAGE5 REMATERIALIZE] table_values_at_r_addr:\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 REMATERIALIZE] table_values_at_r_addr:\n", .{});
+                        }
                         for (0..NUM_TABLES) |t_idx| {
                             if (!table_values[t_idx].eql(F.zero())) {
-                                dbg("  table[{}] = {x}\n", .{ t_idx, table_values[t_idx].toBytesBE()[16..32].* });
+                                if (comptime debug_verbose) {
+                                    dbg("  table[{}] = {x}\n", .{ t_idx, table_values[t_idx].toBytesBE()[16..32].* });
+                                }
                             }
                         }
 
@@ -4913,9 +5173,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 }
                                 sum_with_original = sum_with_original.add(fj_eq.mul(fj_ra).mul(lookups_combined_vals[fj]));
                             }
-                            dbg("[PRE_REMAT_SUM] sum_with_ORIGINAL_cv = {x}\n", .{sum_with_original.toBytesBE()[16..32].*});
-                            dbg("[PRE_REMAT_SUM] lookups_claim         = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                            dbg("[PRE_REMAT_SUM] MATCH: {}\n", .{sum_with_original.eql(lookups_claim)});
+                            if (comptime debug_verbose) {
+                                dbg("[PRE_REMAT_SUM] sum_with_ORIGINAL_cv = {x}\n", .{sum_with_original.toBytesBE()[16..32].*});
+                                dbg("[PRE_REMAT_SUM] lookups_claim         = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                                dbg("[PRE_REMAT_SUM] MATCH: {}\n", .{sum_with_original.eql(lookups_claim)});
+                            }
                         }
 
                         // Rematerialize combined_vals using the correct formula
@@ -4954,17 +5216,21 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         }
 
                         // Debug: print first 5 rematerialized values
-                        dbg("[STAGE5 REMATERIALIZE] First 5 combined_vals after rematerialization:\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 REMATERIALIZE] First 5 combined_vals after rematerialization:\n", .{});
+                        }
                         for (0..@min(5, trace_len)) |j| {
                             const table_idx_dbg = cycle_table_indices[j];
                             const table_val_dbg = if (table_idx_dbg >= 0 and @as(usize, @intCast(table_idx_dbg)) < NUM_TABLES) table_values[@intCast(table_idx_dbg)] else F.zero();
-                            dbg("  j={}: combined_val={x}, is_identity_path={}, table_idx={}, table_val={x}\n", .{
-                                j,
-                                lookups_combined_vals[j].toBytesBE()[24..32].*,
-                                cycle_is_identity_path[j],
-                                table_idx_dbg,
-                                table_val_dbg.toBytesBE()[24..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("  j={}: combined_val={x}, is_identity_path={}, table_idx={}, table_val={x}\n", .{
+                                    j,
+                                    lookups_combined_vals[j].toBytesBE()[24..32].*,
+                                    cycle_is_identity_path[j],
+                                    table_idx_dbg,
+                                    table_val_dbg.toBytesBE()[24..32].*,
+                                });
+                            }
                         }
 
                         // ============================================================
@@ -4988,18 +5254,24 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             for (0..T) |jj| {
                                 condensed_sum = condensed_sum.add(lookups_eq_evals[jj].mul(lookups_combined_vals[jj]));
                             }
-                            dbg("[CONDENSED_DIAG] Σ condensed_eq * cv_remat = {x}\n", .{condensed_sum.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] match = {}\n", .{condensed_sum.eql(lookups_claim)});
+                            if (comptime debug_verbose) {
+                                dbg("[CONDENSED_DIAG] Σ condensed_eq * cv_remat = {x}\n", .{condensed_sum.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] match = {}\n", .{condensed_sum.eql(lookups_claim)});
+                            }
 
                             // Also check: condensed_u_eval[0] vs eq_fresh(0) * ra(0)
                             const fresh_eq_0 = computeEqAtIndex(r_reduction, 0);
-                            dbg("[CONDENSED_DIAG] condensed_eq[0] = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] fresh_eq(0) = {x}\n", .{fresh_eq_0.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] ra_weights[0] = {x}\n", .{lookups_ra_weights[0].toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[CONDENSED_DIAG] condensed_eq[0] = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] fresh_eq(0) = {x}\n", .{fresh_eq_0.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] ra_weights[0] = {x}\n", .{lookups_ra_weights[0].toBytesBE()[16..32].*});
+                            }
                             const expected_condensed_0 = fresh_eq_0.mul(lookups_ra_weights[0]);
-                            dbg("[CONDENSED_DIAG] fresh_eq(0) * ra(0) = {x}\n", .{expected_condensed_0.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] condensed_eq[0] == fresh*ra: {}\n", .{lookups_eq_evals[0].eql(expected_condensed_0)});
+                            if (comptime debug_verbose) {
+                                dbg("[CONDENSED_DIAG] fresh_eq(0) * ra(0) = {x}\n", .{expected_condensed_0.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] condensed_eq[0] == fresh*ra: {}\n", .{lookups_eq_evals[0].eql(expected_condensed_0)});
+                            }
 
                             // Check if the missing factor is v[7][k_bound_7]
                             // For cycle 0: k = 0x8000, phase 7 shift = 0, k_bound_7 = 0x8000
@@ -5011,10 +5283,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             const v7_val = expanding_tables[num_phases - 1].get(k_bound_7_masked);
                             const expected_with_v7 = expected_condensed_0.mul(v7_val);
                             _ = k_hi_0_diag;
-                            dbg("[CONDENSED_DIAG] k_lo_0=0x{x}, k_bound_7=0x{x}, k_bound_7_masked=0x{x}\n", .{k_lo_0_diag, k_bound_7, k_bound_7_masked});
-                            dbg("[CONDENSED_DIAG] v[7][0x{x}] = {x}\n", .{k_bound_7_masked, v7_val.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] fresh*ra_partial(0..6) = {x}\n", .{expected_condensed_0.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] fresh*ra_partial * v7 = {x}\n", .{expected_with_v7.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[CONDENSED_DIAG] k_lo_0=0x{x}, k_bound_7=0x{x}, k_bound_7_masked=0x{x}\n", .{k_lo_0_diag, k_bound_7, k_bound_7_masked});
+                                dbg("[CONDENSED_DIAG] v[7][0x{x}] = {x}\n", .{k_bound_7_masked, v7_val.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] fresh*ra_partial(0..6) = {x}\n", .{expected_condensed_0.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] fresh*ra_partial * v7 = {x}\n", .{expected_with_v7.toBytesBE()[16..32].*});
+                            }
 
                             // Also compute ra_partial = Π_{p=0}^{6} v[p][k_p(0)]
                             var ra_partial = F.one();
@@ -5030,9 +5304,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 ra_partial = ra_partial.mul(expanding_tables[pp].get(k_pp));
                             }
                             const fresh_ra_partial = fresh_eq_0.mul(ra_partial);
-                            dbg("[CONDENSED_DIAG] ra_partial (phases 0-6) = {x}\n", .{ra_partial.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] fresh*ra_partial (phases 0-6) = {x}\n", .{fresh_ra_partial.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] condensed_eq[0] == fresh*ra_partial: {}\n", .{lookups_eq_evals[0].eql(fresh_ra_partial)});
+                            if (comptime debug_verbose) {
+                                dbg("[CONDENSED_DIAG] ra_partial (phases 0-6) = {x}\n", .{ra_partial.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] fresh*ra_partial (phases 0-6) = {x}\n", .{fresh_ra_partial.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] condensed_eq[0] == fresh*ra_partial: {}\n", .{lookups_eq_evals[0].eql(fresh_ra_partial)});
+                            }
 
                             // Now compute Σ condensed_eq(j) * v[15][k_15(j)] * cv_remat(j)
                             // This should equal the claim
@@ -5051,9 +5327,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     lookups_eq_evals[jj].mul(v_last).mul(lookups_combined_vals[jj])
                                 );
                             }
-                            dbg("[CONDENSED_DIAG] Σ condensed * v[15] * cv_remat = {x}\n", .{sum_with_last_phase.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                            dbg("[CONDENSED_DIAG] FINAL match = {}\n", .{sum_with_last_phase.eql(lookups_claim)});
+                            if (comptime debug_verbose) {
+                                dbg("[CONDENSED_DIAG] Σ condensed * v[15] * cv_remat = {x}\n", .{sum_with_last_phase.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                                dbg("[CONDENSED_DIAG] FINAL match = {}\n", .{sum_with_last_phase.eql(lookups_claim)});
+                            }
 
                             // PER-OPCODE DIAGNOSTIC: Break down sum by opcode type
                             var sum_padding = F.zero();
@@ -5084,11 +5362,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     }
                                 }
                             }
-                            dbg("[OPCODE_DIAG] padding: count={}, sum={x}\n", .{count_padding, sum_padding.toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] regular: count={}, sum={x}\n", .{count_regular, sum_regular.toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] virtual: count={}, sum={x}\n", .{count_virtual, sum_virtual.toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] total (pad+reg+virt) = {x}\n", .{sum_padding.add(sum_regular).add(sum_virtual).toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] claim               = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[OPCODE_DIAG] padding: count={}, sum={x}\n", .{count_padding, sum_padding.toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] regular: count={}, sum={x}\n", .{count_regular, sum_regular.toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] virtual: count={}, sum={x}\n", .{count_virtual, sum_virtual.toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] total (pad+reg+virt) = {x}\n", .{sum_padding.add(sum_regular).add(sum_virtual).toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] claim               = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            }
 
                             // Also compute what the chain gives for virtual vs non-virtual
                             // by computing partial sums without virtual cycles
@@ -5107,10 +5387,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     lookups_eq_evals[jj3].mul(v_last3).mul(lookups_combined_vals[jj3])
                                 );
                             }
-                            dbg("[OPCODE_DIAG] sum_without_virtual = {x}\n", .{sum_without_virtual.toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] claim - sum_without_virtual = {x}\n", .{lookups_claim.sub(sum_without_virtual).toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] sum_virtual                = {x}\n", .{sum_virtual.toBytesBE()[16..32].*});
-                            dbg("[OPCODE_DIAG] virtual matches remaining: {}\n", .{sum_virtual.eql(lookups_claim.sub(sum_without_virtual))});
+                            if (comptime debug_verbose) {
+                                dbg("[OPCODE_DIAG] sum_without_virtual = {x}\n", .{sum_without_virtual.toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] claim - sum_without_virtual = {x}\n", .{lookups_claim.sub(sum_without_virtual).toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] sum_virtual                = {x}\n", .{sum_virtual.toBytesBE()[16..32].*});
+                                dbg("[OPCODE_DIAG] virtual matches remaining: {}\n", .{sum_virtual.eql(lookups_claim.sub(sum_without_virtual))});
+                            }
 
                             // ============================================================
                             // DECOMPOSED DIAGNOSTIC: Separate TABLE and RAF contributions
@@ -5165,17 +5447,19 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     sum_raf_identity_cycles = sum_raf_identity_cycles.add(eq_ra_d.mul(raf_identity));
                                 }
                             }
-                            dbg("[DECOMP_DIAG] sum_table_only   = {x}\n", .{sum_table_only.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] sum_raf_only     = {x}\n", .{sum_raf_only.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] sum_table+raf    = {x}\n", .{sum_table_only.add(sum_raf_only).toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] lookups_claim    = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] table+raf==claim = {}\n", .{sum_table_only.add(sum_raf_only).eql(lookups_claim)});
-                            dbg("[DECOMP_DIAG] table_virtual    = {x}\n", .{sum_table_virtual.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] table_regular    = {x}\n", .{sum_table_regular.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] raf_virtual      = {x}\n", .{sum_raf_virtual.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] raf_regular       = {x}\n", .{sum_raf_regular.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] raf_interleaved_total = {x}\n", .{sum_raf_interleaved.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] raf_identity_total    = {x}\n", .{sum_raf_identity_cycles.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[DECOMP_DIAG] sum_table_only   = {x}\n", .{sum_table_only.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] sum_raf_only     = {x}\n", .{sum_raf_only.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] sum_table+raf    = {x}\n", .{sum_table_only.add(sum_raf_only).toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] lookups_claim    = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] table+raf==claim = {}\n", .{sum_table_only.add(sum_raf_only).eql(lookups_claim)});
+                                dbg("[DECOMP_DIAG] table_virtual    = {x}\n", .{sum_table_virtual.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] table_regular    = {x}\n", .{sum_table_regular.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] raf_virtual      = {x}\n", .{sum_raf_virtual.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] raf_regular       = {x}\n", .{sum_raf_regular.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] raf_interleaved_total = {x}\n", .{sum_raf_interleaved.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] raf_identity_total    = {x}\n", .{sum_raf_identity_cycles.toBytesBE()[16..32].*});
+                            }
 
                             // Also compute what raf SHOULD be from the eq_ra sum
                             // raf = γ*(1-flag)*left + γ²*(1-flag)*right + γ²*flag*identity
@@ -5197,10 +5481,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 }
                             }
                             const raf_from_sums = raf_interleaved.mul(sum_eq_ra_interleaved).add(raf_identity.mul(sum_eq_ra_identity));
-                            dbg("[DECOMP_DIAG] sum_eq_ra_interleaved = {x}\n", .{sum_eq_ra_interleaved.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] sum_eq_ra_identity    = {x}\n", .{sum_eq_ra_identity.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] raf_from_sums         = {x}\n", .{raf_from_sums.toBytesBE()[16..32].*});
-                            dbg("[DECOMP_DIAG] raf_from_sums==sum_raf_only = {}\n", .{raf_from_sums.eql(sum_raf_only)});
+                            if (comptime debug_verbose) {
+                                dbg("[DECOMP_DIAG] sum_eq_ra_interleaved = {x}\n", .{sum_eq_ra_interleaved.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] sum_eq_ra_identity    = {x}\n", .{sum_eq_ra_identity.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] raf_from_sums         = {x}\n", .{raf_from_sums.toBytesBE()[16..32].*});
+                                dbg("[DECOMP_DIAG] raf_from_sums==sum_raf_only = {}\n", .{raf_from_sums.eql(sum_raf_only)});
+                            }
 
                             // ============================================================
                             // EQ_RA VERIFICATION: Check condensed eq_ra matches fresh computation
@@ -5221,15 +5507,19 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     if (eq_ra_mismatches == 1) first_mismatch_cycle = jv;
                                 }
                                 if (jv < 5 or !match_jv) {
-                                    dbg("[EQ_RA_CHECK j={}] condensed={x}, fresh={x}, match={}\n", .{
-                                        jv,
-                                        eq_ra_condensed.toBytesBE()[24..32].*,
-                                        eq_ra_fresh.toBytesBE()[24..32].*,
-                                        match_jv,
-                                    });
+                                    if (comptime debug_verbose) {
+                                        dbg("[EQ_RA_CHECK j={}] condensed={x}, fresh={x}, match={}\n", .{
+                                            jv,
+                                            eq_ra_condensed.toBytesBE()[24..32].*,
+                                            eq_ra_fresh.toBytesBE()[24..32].*,
+                                            match_jv,
+                                        });
+                                    }
                                 }
                             }
-                            dbg("[EQ_RA_CHECK] mismatches in first 20 cycles: {}\n", .{eq_ra_mismatches});
+                            if (comptime debug_verbose) {
+                                dbg("[EQ_RA_CHECK] mismatches in first 20 cycles: {}\n", .{eq_ra_mismatches});
+                            }
 
                             // Wider check: count mismatches across ALL cycles
                             var eq_ra_total_mismatches: usize = 0;
@@ -5245,12 +5535,16 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     eq_ra_total_mismatches += 1;
                                 }
                             }
-                            dbg("[EQ_RA_CHECK] total mismatches across ALL {} cycles: {}\n", .{T, eq_ra_total_mismatches});
+                            if (comptime debug_verbose) {
+                                dbg("[EQ_RA_CHECK] total mismatches across ALL {} cycles: {}\n", .{T, eq_ra_total_mismatches});
+                            }
 
                             // If eq_ra matches, the problem is in cv_remat
                             // Try computing with fresh eq_ra instead
                             if (eq_ra_total_mismatches == 0) {
-                                dbg("[EQ_RA_CHECK] ALL eq_ra values match! Problem is in cv_remat.\n", .{});
+                                if (comptime debug_verbose) {
+                                    dbg("[EQ_RA_CHECK] ALL eq_ra values match! Problem is in cv_remat.\n", .{});
+                                }
                             } else {
                                 // Compute sum using FRESH eq_ra
                                 var sum_fresh_eq_ra = F.zero();
@@ -5259,21 +5553,27 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     const eq_ra_f = fresh_eq_jf.mul(lookups_ra_weights[jf]);
                                     sum_fresh_eq_ra = sum_fresh_eq_ra.add(eq_ra_f.mul(lookups_combined_vals[jf]));
                                 }
-                                dbg("[EQ_RA_CHECK] sum_with_fresh_eq_ra = {x}\n", .{sum_fresh_eq_ra.toBytesBE()[16..32].*});
-                                dbg("[EQ_RA_CHECK] matches claim: {}\n", .{sum_fresh_eq_ra.eql(lookups_claim)});
+                                if (comptime debug_verbose) {
+                                    dbg("[EQ_RA_CHECK] sum_with_fresh_eq_ra = {x}\n", .{sum_fresh_eq_ra.toBytesBE()[16..32].*});
+                                    dbg("[EQ_RA_CHECK] matches claim: {}\n", .{sum_fresh_eq_ra.eql(lookups_claim)});
+                                }
                             }
                         }
 
-                        dbg("[STAGE5 CYCLE] Reinitializing lookups_eq_evals for cycle rounds\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE] Reinitializing lookups_eq_evals for cycle rounds\n", .{});
+                        }
                         buildFullEqTable(r_reduction, lookups_eq_evals[0..T]);
                         // Debug: verify sum = 1
                         var eq_sum_verify = F.zero();
                         for (0..T) |j| {
                             eq_sum_verify = eq_sum_verify.add(lookups_eq_evals[j]);
                         }
-                        dbg("[STAGE5 CYCLE] eq_sum after reinit = {x} (should be 1)\n", .{eq_sum_verify.toBytesBE()[16..32].*});
-                        dbg("[STAGE5 CYCLE] reinit eq_evals[0] = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
-                        dbg("[STAGE5 CYCLE] reinit eq_evals[1] = {x}\n", .{lookups_eq_evals[1].toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE] eq_sum after reinit = {x} (should be 1)\n", .{eq_sum_verify.toBytesBE()[16..32].*});
+                            dbg("[STAGE5 CYCLE] reinit eq_evals[0] = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
+                            dbg("[STAGE5 CYCLE] reinit eq_evals[1] = {x}\n", .{lookups_eq_evals[1].toBytesBE()[16..32].*});
+                        }
 
                         // ============================================================
                         // CRITICAL FIX: Materialize ra_chunk_weights from expanding tables
@@ -5288,27 +5588,37 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         // Each chunk covers (phases_per_chunk) phases, where:
                         //   phases_per_chunk = num_phases / ra_num_chunks = 8 / 8 = 1
                         //   chunk_i handles phases [chunk_i * phases_per_chunk, (chunk_i+1) * phases_per_chunk)
-                        dbg("[STAGE5 CYCLE] Materializing ra_chunk_weights from expanding tables\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE] Materializing ra_chunk_weights from expanding tables\n", .{});
+                        }
                         const phases_per_chunk = num_phases / ra_num_chunks;
-                        dbg("  num_phases={}, ra_num_chunks={}, phases_per_chunk={}\n", .{ num_phases, ra_num_chunks, phases_per_chunk });
+                        if (comptime debug_verbose) {
+                            dbg("  num_phases={}, ra_num_chunks={}, phases_per_chunk={}\n", .{ num_phases, ra_num_chunks, phases_per_chunk });
+                        }
 
                         // Debug: print expanding table sizes and first few values
-                        dbg("  Expanding table state at round 128:\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("  Expanding table state at round 128:\n", .{});
+                        }
                         const v0_p0 = expanding_tables[0].get(0);
                         const v0_p1 = expanding_tables[1].get(0);
                         const product_check = v0_p0.mul(v0_p1);
-                        dbg("    phase[0] v[0] (full) = {x}\n", .{v0_p0.toBytesBE()[16..32].*});
-                        dbg("    phase[1] v[0] (full) = {x}\n", .{v0_p1.toBytesBE()[16..32].*});
-                        dbg("    product v0_p0 * v0_p1 = {x}\n", .{product_check.toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("    phase[0] v[0] (full) = {x}\n", .{v0_p0.toBytesBE()[16..32].*});
+                            dbg("    phase[1] v[0] (full) = {x}\n", .{v0_p1.toBytesBE()[16..32].*});
+                            dbg("    product v0_p0 * v0_p1 = {x}\n", .{product_check.toBytesBE()[16..32].*});
+                        }
                         for (0..@min(4, num_phases)) |phase| {
-                            dbg("    phase[{}]: len={}, first_vals=[{x}, {x}, {x}, {x}]\n", .{
-                                phase,
-                                expanding_tables[phase].getLen(),
-                                expanding_tables[phase].get(0).toBytesBE()[28..32].*,
-                                expanding_tables[phase].get(1).toBytesBE()[28..32].*,
-                                expanding_tables[phase].get(2).toBytesBE()[28..32].*,
-                                expanding_tables[phase].get(3).toBytesBE()[28..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("    phase[{}]: len={}, first_vals=[{x}, {x}, {x}, {x}]\n", .{
+                                    phase,
+                                    expanding_tables[phase].getLen(),
+                                    expanding_tables[phase].get(0).toBytesBE()[28..32].*,
+                                    expanding_tables[phase].get(1).toBytesBE()[28..32].*,
+                                    expanding_tables[phase].get(2).toBytesBE()[28..32].*,
+                                    expanding_tables[phase].get(3).toBytesBE()[28..32].*,
+                                });
+                            }
                         }
 
                         // DIAGNOSTIC: Compare accumulated ra_chunk_weights with materialized values
@@ -5329,7 +5639,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                             // Debug: print lookup index for first cycle
                             if (j == 0) {
-                                dbg("[STAGE5 RA_DEBUG] Cycle 0 lookup_index: k_hi=0x{x:0>16}, k_lo=0x{x:0>16}\n", .{ k_hi, k_lo });
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 RA_DEBUG] Cycle 0 lookup_index: k_hi=0x{x:0>16}, k_lo=0x{x:0>16}\n", .{ k_hi, k_lo });
+                                }
                             }
 
                             // For each chunk, compute the product of expanding table lookups
@@ -5377,13 +5689,15 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                                     // Debug: print detailed info for first cycle
                                     if (j == 0 and chunk_idx < 2) {
-                                        dbg("[STAGE5 RA_DEBUG] j=0, chunk={}, phase={}: shift={}, k_phase=0x{x}, table_val={x}\n", .{
-                                            chunk_idx,
-                                            phase,
-                                            shift,
-                                            k_phase,
-                                            table_val.toBytesBE()[28..32].*,
-                                        });
+                                        if (comptime debug_verbose) {
+                                            dbg("[STAGE5 RA_DEBUG] j=0, chunk={}, phase={}: shift={}, k_phase=0x{x}, table_val={x}\n", .{
+                                                chunk_idx,
+                                                phase,
+                                                shift,
+                                                k_phase,
+                                                table_val.toBytesBE()[28..32].*,
+                                            });
+                                        }
                                     }
 
                                     ra_val = ra_val.mul(table_val);
@@ -5393,37 +5707,51 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                                 // Debug: print final ra_val for first cycle, first 2 chunks
                                 if (j == 0 and chunk_idx < 2) {
-                                    dbg("[STAGE5 RA_DEBUG] j=0, chunk={}: final ra_val={x}\n", .{
-                                        chunk_idx,
-                                        ra_val.toBytesBE()[16..32].*,
-                                    });
+                                    if (comptime debug_verbose) {
+                                        dbg("[STAGE5 RA_DEBUG] j=0, chunk={}: final ra_val={x}\n", .{
+                                            chunk_idx,
+                                            ra_val.toBytesBE()[16..32].*,
+                                        });
+                                    }
                                 }
                             }
                         }
 
                         // Debug: print first few ra_chunk_weights after materialization
-                        dbg("[STAGE5 CYCLE] ra_chunk_weights after materialization (first 4 cycles):\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE] ra_chunk_weights after materialization (first 4 cycles):\n", .{});
+                        }
                         for (0..@min(4, T)) |j| {
-                            dbg("  j={}: ra_chunks=[", .{j});
-                            for (0..ra_num_chunks) |c| {
-                                if (c > 0) dbg(", ", .{});
-                                dbg("{x}", .{ra_chunk_weights[c][j].toBytesBE()[24..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("  j={}: ra_chunks=[", .{j});
                             }
-                            dbg("]\n", .{});
+                            for (0..ra_num_chunks) |c| {
+                                if (comptime debug_verbose) {
+                                    if (c > 0) dbg(", ", .{});
+                                    dbg("{x}", .{ra_chunk_weights[c][j].toBytesBE()[24..32].*});
+                                }
+                            }
+                            if (comptime debug_verbose) {
+                                dbg("]\n", .{});
+                            }
                         }
 
                         // DIAGNOSTIC: Compare accumulated vs materialized for cycle 0
-                        dbg("[RA_ACCUM_VS_MATERIAL] Comparing for cycle 0:\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[RA_ACCUM_VS_MATERIAL] Comparing for cycle 0:\n", .{});
+                        }
                         for (0..@min(ra_num_chunks, 8)) |c| {
                             const materialized = ra_chunk_weights[c][0];
                             const accumulated = accum_ra_debug[c];
                             const match_val = materialized.eql(accumulated);
-                            dbg("  chunk[{}]: accum={x}, material={x}, match={}\n", .{
-                                c,
-                                accumulated.toBytesBE()[16..32].*,
-                                materialized.toBytesBE()[16..32].*,
-                                match_val,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("  chunk[{}]: accum={x}, material={x}, match={}\n", .{
+                                    c,
+                                    accumulated.toBytesBE()[16..32].*,
+                                    materialized.toBytesBE()[16..32].*,
+                                    match_val,
+                                });
+                            }
                         }
 
                         // Also compute the FULL sum with both: using accumulated ra and using materialized ra
@@ -5437,9 +5765,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             }
                             sum_with_material = sum_with_material.add(eq_j.mul(ra_material).mul(lookups_combined_vals[j]));
                         }
-                        dbg("[RA_COMPARE] sum_with_material = {x}\n", .{sum_with_material.toBytesBE()[16..32].*});
-                        dbg("[RA_COMPARE] lookups_claim     = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                        dbg("[RA_COMPARE] material==claim: {}\n", .{sum_with_material.eql(lookups_claim)});
+                        if (comptime debug_verbose) {
+                            dbg("[RA_COMPARE] sum_with_material = {x}\n", .{sum_with_material.toBytesBE()[16..32].*});
+                            dbg("[RA_COMPARE] lookups_claim     = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            dbg("[RA_COMPARE] material==claim: {}\n", .{sum_with_material.eql(lookups_claim)});
+                        }
 
                         // Update lookups_ra_weights[j] to be the product of all chunks
                         for (0..T) |j| {
@@ -5467,9 +5797,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 const eq_bit = if (k_bit == 1) r_i else F.one().sub(r_i);
                                 direct_eq = direct_eq.mul(eq_bit);
                             }
-                            dbg("[STAGE5 RA_VERIFY] Direct eq(K(0), r_addr) = {x}\n", .{direct_eq.toBytesBE()[16..32].*});
-                            dbg("[STAGE5 RA_VERIFY] Product of ra_chunks(0) = {x}\n", .{lookups_ra_weights[0].toBytesBE()[16..32].*});
-                            dbg("[STAGE5 RA_VERIFY] Match = {}\n", .{direct_eq.eql(lookups_ra_weights[0])});
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 RA_VERIFY] Direct eq(K(0), r_addr) = {x}\n", .{direct_eq.toBytesBE()[16..32].*});
+                                dbg("[STAGE5 RA_VERIFY] Product of ra_chunks(0) = {x}\n", .{lookups_ra_weights[0].toBytesBE()[16..32].*});
+                                dbg("[STAGE5 RA_VERIFY] Match = {}\n", .{direct_eq.eql(lookups_ra_weights[0])});
+                            }
                         }
 
                         // DEBUG: Compute combined_val(0) directly from table MLE
@@ -5479,15 +5811,23 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             // For cycle 0: what table is it?
                             const t_idx_0 = cycle_table_indices[0];
                             const is_id_0 = cycle_is_identity_path[0];
-                            dbg("[STAGE5 CV_VERIFY] Cycle 0: table_idx={}, is_identity={}\n", .{t_idx_0, is_id_0});
-                            dbg("[STAGE5 CV_VERIFY] combined_vals[0] = {x}\n", .{lookups_combined_vals[0].toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 CV_VERIFY] Cycle 0: table_idx={}, is_identity={}\n", .{t_idx_0, is_id_0});
+                                dbg("[STAGE5 CV_VERIFY] combined_vals[0] = {x}\n", .{lookups_combined_vals[0].toBytesBE()[16..32].*});
+                            }
                             if (t_idx_0 >= 0) {
-                                dbg("[STAGE5 CV_VERIFY] table_val = {x}\n", .{stored_table_values[@intCast(t_idx_0)].toBytesBE()[16..32].*});
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 CV_VERIFY] table_val = {x}\n", .{stored_table_values[@intCast(t_idx_0)].toBytesBE()[16..32].*});
+                                }
                             }
                             if (is_id_0) {
-                                dbg("[STAGE5 CV_VERIFY] raf_identity = {x}\n", .{raf_identity.toBytesBE()[16..32].*});
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 CV_VERIFY] raf_identity = {x}\n", .{raf_identity.toBytesBE()[16..32].*});
+                                }
                             } else {
-                                dbg("[STAGE5 CV_VERIFY] raf_interleaved = {x}\n", .{raf_interleaved.toBytesBE()[16..32].*});
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 CV_VERIFY] raf_interleaved = {x}\n", .{raf_interleaved.toBytesBE()[16..32].*});
+                                }
                             }
 
                             // Also verify: sum over j of eq(j) * eq(K(j), r_addr) * cv(j)
@@ -5499,14 +5839,16 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 const cv_j = lookups_combined_vals[jj];
                                 const contrib_j = eq_j.mul(ra_j).mul(cv_j);
                                 direct_sum_5 = direct_sum_5.add(contrib_j);
-                                dbg("[STAGE5 CYCLE_SUM] j={}: eq={x}, ra={x}, cv={x}, contrib={x}, running={x}\n", .{
-                                    jj,
-                                    eq_j.toBytesBE()[24..32].*,
-                                    ra_j.toBytesBE()[24..32].*,
-                                    cv_j.toBytesBE()[24..32].*,
-                                    contrib_j.toBytesBE()[24..32].*,
-                                    direct_sum_5.toBytesBE()[24..32].*,
-                                });
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 CYCLE_SUM] j={}: eq={x}, ra={x}, cv={x}, contrib={x}, running={x}\n", .{
+                                        jj,
+                                        eq_j.toBytesBE()[24..32].*,
+                                        ra_j.toBytesBE()[24..32].*,
+                                        cv_j.toBytesBE()[24..32].*,
+                                        contrib_j.toBytesBE()[24..32].*,
+                                        direct_sum_5.toBytesBE()[24..32].*,
+                                    });
+                                }
                             }
                         }
 
@@ -5536,9 +5878,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 // Check: direct_ra vs ra_weights
                                 if (!direct_ra.eql(lookups_ra_weights[j])) {
                                     if (mismatch_count < 3) {
-                                        dbg("[DIRECT_BF] ra MISMATCH at j={}: direct={x}, ra_weights={x}\n", .{
-                                            j, direct_ra.toBytesBE()[24..32].*, lookups_ra_weights[j].toBytesBE()[24..32].*,
-                                        });
+                                        if (comptime debug_verbose) {
+                                            dbg("[DIRECT_BF] ra MISMATCH at j={}: direct={x}, ra_weights={x}\n", .{
+                                                j, direct_ra.toBytesBE()[24..32].*, lookups_ra_weights[j].toBytesBE()[24..32].*,
+                                            });
+                                        }
                                     }
                                     mismatch_count += 1;
                                 }
@@ -5557,12 +5901,14 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             for (0..T) |j2| {
                                 mat_sum_check = mat_sum_check.add(lookups_eq_evals[j2].mul(lookups_ra_weights[j2]).mul(lookups_combined_vals[j2]));
                             }
-                            dbg("[DIRECT_BF] ra_weights mismatches: {}/{}\n", .{mismatch_count, T});
-                            dbg("[DIRECT_BF] Σ eq*direct_ra*cv_remat = {x}\n", .{direct_bf_sum.toBytesBE()[16..32].*});
-                            dbg("[DIRECT_BF] materialized_sum (ra_weights) = {x}\n", .{mat_sum_check.toBytesBE()[16..32].*});
-                            dbg("[DIRECT_BF] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                            dbg("[DIRECT_BF] direct_bf == materialized: {}\n", .{direct_bf_sum.eql(mat_sum_check)});
-                            dbg("[DIRECT_BF] direct_bf == lookups_claim: {}\n", .{direct_bf_sum.eql(lookups_claim)});
+                            if (comptime debug_verbose) {
+                                dbg("[DIRECT_BF] ra_weights mismatches: {}/{}\n", .{mismatch_count, T});
+                                dbg("[DIRECT_BF] Σ eq*direct_ra*cv_remat = {x}\n", .{direct_bf_sum.toBytesBE()[16..32].*});
+                                dbg("[DIRECT_BF] materialized_sum (ra_weights) = {x}\n", .{mat_sum_check.toBytesBE()[16..32].*});
+                                dbg("[DIRECT_BF] lookups_claim (poly chain) = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                                dbg("[DIRECT_BF] direct_bf == materialized: {}\n", .{direct_bf_sum.eql(mat_sum_check)});
+                                dbg("[DIRECT_BF] direct_bf == lookups_claim: {}\n", .{direct_bf_sum.eql(lookups_claim)});
+                            }
 
                             // KEY TEST: The claim should equal materialized_sum.
                             // If direct_bf matches materialized but not claim, then
@@ -5582,7 +5928,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             //
                             // Let me check the initial claim structure more carefully.
                             // Print lookups_input for reference
-                            dbg("[DIRECT_BF] lookups_input (initial claim) = {x}\n", .{lookups_input.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[DIRECT_BF] lookups_input (initial claim) = {x}\n", .{lookups_input.toBytesBE()[16..32].*});
+                            }
 
                             // SPLIT TEST: Compute sum with table-only (no RAF) and RAF-only (no table)
                             var table_only_sum = F.zero();
@@ -5609,11 +5957,13 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     raf_only_sum = raf_only_sum.add(eq_ra.mul(raf_identity));
                                 }
                             }
-                            dbg("[SPLIT_TEST] table_only_sum = {x}\n", .{table_only_sum.toBytesBE()[16..32].*});
-                            dbg("[SPLIT_TEST] raf_only_sum = {x}\n", .{raf_only_sum.toBytesBE()[16..32].*});
-                            dbg("[SPLIT_TEST] table+raf = {x}\n", .{table_only_sum.add(raf_only_sum).toBytesBE()[16..32].*});
-                            dbg("[SPLIT_TEST] materialized = {x}\n", .{mat_sum_check.toBytesBE()[16..32].*});
-                            dbg("[SPLIT_TEST] split matches materialized: {}\n", .{table_only_sum.add(raf_only_sum).eql(mat_sum_check)});
+                            if (comptime debug_verbose) {
+                                dbg("[SPLIT_TEST] table_only_sum = {x}\n", .{table_only_sum.toBytesBE()[16..32].*});
+                                dbg("[SPLIT_TEST] raf_only_sum = {x}\n", .{raf_only_sum.toBytesBE()[16..32].*});
+                                dbg("[SPLIT_TEST] table+raf = {x}\n", .{table_only_sum.add(raf_only_sum).toBytesBE()[16..32].*});
+                                dbg("[SPLIT_TEST] materialized = {x}\n", .{mat_sum_check.toBytesBE()[16..32].*});
+                                dbg("[SPLIT_TEST] split matches materialized: {}\n", .{table_only_sum.add(raf_only_sum).eql(mat_sum_check)});
+                            }
 
                             // Now compute what the initial sum SHOULD be after binding
                             // Initial: Σ_j eq(j,r) * [table(K(j)) + γ*raf(K(j))]
@@ -5626,7 +5976,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             //
                             // So the claim should be table_only_sum + raf_only_sum
                             // And this should equal lookups_claim
-                            dbg("[SPLIT_TEST] lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[SPLIT_TEST] lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            }
                         }
                     }
                     // Verify full sum at the start of cycle rounds (debug only)
@@ -5724,17 +6076,19 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                         // Debug: for first cycle round, first few j values
                         if (lookups_round == 0 and j < 3) {
-                            dbg("[CYCLE R0 DEBUG] j={}, remaining_vars={}, eq_prefix={x}\n", .{
-                                j,
-                                remaining_vars,
-                                eq_prefix.toBytesBE()[16..32].*,
-                            });
-                            dbg("  combined_vals[{}]={x}, combined_vals[{}]={x}\n", .{
-                                2 * j,
-                                lookups_combined_vals[2 * j].toBytesBE()[16..32].*,
-                                2 * j + 1,
-                                lookups_combined_vals[2 * j + 1].toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[CYCLE R0 DEBUG] j={}, remaining_vars={}, eq_prefix={x}\n", .{
+                                    j,
+                                    remaining_vars,
+                                    eq_prefix.toBytesBE()[16..32].*,
+                                });
+                                dbg("  combined_vals[{}]={x}, combined_vals[{}]={x}\n", .{
+                                    2 * j,
+                                    lookups_combined_vals[2 * j].toBytesBE()[16..32].*,
+                                    2 * j + 1,
+                                    lookups_combined_vals[2 * j + 1].toBytesBE()[16..32].*,
+                                });
+                            }
                         }
 
                         // combined_vals IS bound (standard MLE binding), so use sequential access
@@ -5793,42 +6147,54 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     const sumcheck_ok = sum_check.eql(cycle_claim);
 
                     // Debug: print polynomial info for all cycle rounds
-                    dbg("[STAGE5 CYCLE] Round {} (cycle var {}):\n", .{ round, lookups_round });
-                    dbg("  r_round = {x}\n", .{r_round.toBytesBE()[24..32].*});
-                    dbg("  lookups_current_scalar = {x}\n", .{lookups_current_scalar.toBytesBE()[24..32].*});
-                    dbg("  cycle_claim = {x}\n", .{cycle_claim.toBytesBE()[24..32].*});
-                    dbg("  p(0) = {x}\n", .{p_at_0.toBytesBE()[24..32].*});
-                    dbg("  p(1) = {x}\n", .{p_at_1.toBytesBE()[24..32].*});
-                    dbg("  p(0)+p(1) = {x}, matches_claim = {}\n", .{ sum_check.toBytesBE()[24..32].*, sumcheck_ok });
-                    dbg("  full_coeffs len = {}\n", .{full_coeffs.len});
-                    // Print sum_evals to debug
-                    dbg("  sum_evals = [\n", .{});
-                    for (0..9) |k| {
-                        dbg("    [{d}] = {x}\n", .{ k, sum_evals[k].toBytesBE()[24..32].* });
+                    if (comptime debug_verbose) {
+                        dbg("[STAGE5 CYCLE] Round {} (cycle var {}):\n", .{ round, lookups_round });
+                        dbg("  r_round = {x}\n", .{r_round.toBytesBE()[24..32].*});
+                        dbg("  lookups_current_scalar = {x}\n", .{lookups_current_scalar.toBytesBE()[24..32].*});
+                        dbg("  cycle_claim = {x}\n", .{cycle_claim.toBytesBE()[24..32].*});
+                        dbg("  p(0) = {x}\n", .{p_at_0.toBytesBE()[24..32].*});
+                        dbg("  p(1) = {x}\n", .{p_at_1.toBytesBE()[24..32].*});
+                        dbg("  p(0)+p(1) = {x}, matches_claim = {}\n", .{ sum_check.toBytesBE()[24..32].*, sumcheck_ok });
+                        dbg("  full_coeffs len = {}\n", .{full_coeffs.len});
                     }
-                    dbg("  ]\n", .{});
+                    // Print sum_evals to debug
+                    if (comptime debug_verbose) {
+                        dbg("  sum_evals = [\n", .{});
+                    }
+                    for (0..9) |k| {
+                        if (comptime debug_verbose) {
+                            dbg("    [{d}] = {x}\n", .{ k, sum_evals[k].toBytesBE()[24..32].* });
+                        }
+                    }
+                    if (comptime debug_verbose) {
+                        dbg("  ]\n", .{});
+                    }
                     // Debug: print eq and combined values for last round
                     if (lookups_round == n_cycle_vars - 1) {
-                        dbg("  [LAST ROUND] eq[0]={x}, eq[1]={x}\n", .{
-                            lookups_eq_evals[0].toBytesBE()[16..32].*,
-                            lookups_eq_evals[1].toBytesBE()[16..32].*,
-                        });
-                        dbg("  [LAST ROUND] val[0]={x}, val[1]={x}\n", .{
-                            lookups_combined_vals[0].toBytesBE()[16..32].*,
-                            lookups_combined_vals[1].toBytesBE()[16..32].*,
-                        });
-                        dbg("  [LAST ROUND] ra_chunk[0]: [{x}, {x}]\n", .{
-                            ra_chunk_weights[0][0].toBytesBE()[16..32].*,
-                            ra_chunk_weights[0][1].toBytesBE()[16..32].*,
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("  [LAST ROUND] eq[0]={x}, eq[1]={x}\n", .{
+                                lookups_eq_evals[0].toBytesBE()[16..32].*,
+                                lookups_eq_evals[1].toBytesBE()[16..32].*,
+                            });
+                            dbg("  [LAST ROUND] val[0]={x}, val[1]={x}\n", .{
+                                lookups_combined_vals[0].toBytesBE()[16..32].*,
+                                lookups_combined_vals[1].toBytesBE()[16..32].*,
+                            });
+                            dbg("  [LAST ROUND] ra_chunk[0]: [{x}, {x}]\n", .{
+                                ra_chunk_weights[0][0].toBytesBE()[16..32].*,
+                                ra_chunk_weights[0][1].toBytesBE()[16..32].*,
+                            });
+                        }
                     }
                     // Print Instance 0+1 contribution
-                    dbg("  combined_poly (Inst 0+1) = [{x}, {x}, {x}, {x}]\n", .{
-                        combined_poly[0].toBytesBE()[24..32].*,
-                        combined_poly[1].toBytesBE()[24..32].*,
-                        combined_poly[2].toBytesBE()[24..32].*,
-                        combined_poly[3].toBytesBE()[24..32].*,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("  combined_poly (Inst 0+1) = [{x}, {x}, {x}, {x}]\n", .{
+                            combined_poly[0].toBytesBE()[24..32].*,
+                            combined_poly[1].toBytesBE()[24..32].*,
+                            combined_poly[2].toBytesBE()[24..32].*,
+                            combined_poly[3].toBytesBE()[24..32].*,
+                        });
+                    }
 
                     // For the batched sumcheck, we need to add Instance 2's polynomial to the combined polynomial
                     // The combined polynomial format depends on whether we're in a cycle round
@@ -5866,26 +6232,38 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print first 3 compressed coefficients (excluding linear term) in LE format
                     if (round == 135) { // Only Round 135
-                        dbg("[STAGE5 CYCLE ZOLT] Round {} compressed coeffs (LE, comparing to Jolt):\n", .{round});
-                        dbg("  final_compressed.len = {}\n", .{final_compressed.len});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE ZOLT] Round {} compressed coeffs (LE, comparing to Jolt):\n", .{round});
+                            dbg("  final_compressed.len = {}\n", .{final_compressed.len});
+                        }
                         for (0..final_compressed.len) |k| {
                             // Jolt displays LE bytes from arkworks serialization
-                            dbg("  coeff[{}] = {any}\n", .{ k, final_compressed[k].toBytes() });
+                            if (comptime debug_verbose) {
+                                dbg("  coeff[{}] = {any}\n", .{ k, final_compressed[k].toBytes() });
+                            }
                         }
-                        dbg("  current_batched_claim (LE) = {any}\n", .{current_batched_claim.toBytes()});
+                        if (comptime debug_verbose) {
+                            dbg("  current_batched_claim (LE) = {any}\n", .{current_batched_claim.toBytes()});
+                        }
                         // Also print combined_coeffs before compression
-                        dbg("  combined_coeffs[0] (c0) = {any}\n", .{combined_coeffs[0].toBytes()});
-                        dbg("  combined_coeffs[1] (c1) = {any}\n", .{combined_coeffs[1].toBytes()});
-                        dbg("  combined_coeffs[2] (c2) = {any}\n", .{combined_coeffs[2].toBytes()});
+                        if (comptime debug_verbose) {
+                            dbg("  combined_coeffs[0] (c0) = {any}\n", .{combined_coeffs[0].toBytes()});
+                            dbg("  combined_coeffs[1] (c1) = {any}\n", .{combined_coeffs[1].toBytes()});
+                            dbg("  combined_coeffs[2] (c2) = {any}\n", .{combined_coeffs[2].toBytes()});
+                        }
                         // Print Instance 0+1 contribution details
-                        dbg("  inst01_coeffs[0..4] = [{any}, {any}, {any}, {any}]\n", .{
-                            inst01_coeffs[0].toBytes(), inst01_coeffs[1].toBytes(),
-                            inst01_coeffs[2].toBytes(), inst01_coeffs[3].toBytes(),
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("  inst01_coeffs[0..4] = [{any}, {any}, {any}, {any}]\n", .{
+                                inst01_coeffs[0].toBytes(), inst01_coeffs[1].toBytes(),
+                                inst01_coeffs[2].toBytes(), inst01_coeffs[3].toBytes(),
+                            });
+                        }
                         // Print full_coeffs (Instance 2)
-                        dbg("  full_coeffs[0..3] = [{any}, {any}, {any}]\n", .{
-                            full_coeffs[0].toBytes(), full_coeffs[1].toBytes(), full_coeffs[2].toBytes(),
-                        });
+                        if (comptime debug_verbose) {
+                            dbg("  full_coeffs[0..3] = [{any}, {any}, {any}]\n", .{
+                                full_coeffs[0].toBytes(), full_coeffs[1].toBytes(), full_coeffs[2].toBytes(),
+                            });
+                        }
                     }
 
                     try proof.compressed_polys.append(self.allocator, .{
@@ -5901,7 +6279,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print challenge for comparison with Jolt
                     if (round < 4 or round >= 128) {
-                        dbg("[STAGE5 CHALLENGE] Round {}: LE = {any}\n", .{round, challenge.toBytes()[0..16].*});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CHALLENGE] Round {}: LE = {any}\n", .{round, challenge.toBytes()[0..16].*});
+                        }
                     }
 
                     // Update current_batched_claim by evaluating polynomial at challenge
@@ -5921,25 +6301,29 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: compare c1_direct vs c1_recovered
                     if (round >= 128) {
-                        dbg("[STAGE5 C1 DEBUG] Round {}:\n", .{round});
-                        dbg("  c1_direct (combined_coeffs[1]) = {any}\n", .{combined_coeffs[1].toBytes()});
-                        dbg("  c1_recovered (from hint)       = {any}\n", .{c1_recovered.toBytes()});
-                        dbg("  hint (current_batched_claim)   = {any}\n", .{current_batched_claim.toBytes()});
-                        dbg("  c1_direct == c1_recovered: {}\n", .{combined_coeffs[1].eql(c1_recovered)});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 C1 DEBUG] Round {}:\n", .{round});
+                            dbg("  c1_direct (combined_coeffs[1]) = {any}\n", .{combined_coeffs[1].toBytes()});
+                            dbg("  c1_recovered (from hint)       = {any}\n", .{c1_recovered.toBytes()});
+                            dbg("  hint (current_batched_claim)   = {any}\n", .{current_batched_claim.toBytes()});
+                            dbg("  c1_direct == c1_recovered: {}\n", .{combined_coeffs[1].eql(c1_recovered)});
+                        }
 
                         // CRITICAL DEBUG: Check if current_batched_claim = sum of scaled instance claims
                         // Expected: batch0*claim0 + batch1*claim1 + batch2*claim2
                         const expected_batched = batch0.mul(regs_val_current_claim)
                             .add(batch1.mul(ram_ra_current_claim))
                             .add(batch2.mul(lookups_claim));
-                        dbg("  expected_batched (batch0*c0+batch1*c1+batch2*c2) = {any}\n", .{expected_batched.toBytes()});
-                        dbg("  current_batched_claim matches expected: {}\n", .{current_batched_claim.eql(expected_batched)});
-                        dbg("    batch0*claim0 = {any}\n", .{batch0.mul(regs_val_current_claim).toBytes()});
-                        dbg("    batch1*claim1 = {any}\n", .{batch1.mul(ram_ra_current_claim).toBytes()});
-                        dbg("    batch2*claim2 = {any}\n", .{batch2.mul(lookups_claim).toBytes()});
-                        dbg("    regs_val_current_claim = {x}\n", .{regs_val_current_claim.toBytesBE()[16..32].*});
-                        dbg("    ram_ra_current_claim   = {x}\n", .{ram_ra_current_claim.toBytesBE()[16..32].*});
-                        dbg("    lookups_claim          = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("  expected_batched (batch0*c0+batch1*c1+batch2*c2) = {any}\n", .{expected_batched.toBytes()});
+                            dbg("  current_batched_claim matches expected: {}\n", .{current_batched_claim.eql(expected_batched)});
+                            dbg("    batch0*claim0 = {any}\n", .{batch0.mul(regs_val_current_claim).toBytes()});
+                            dbg("    batch1*claim1 = {any}\n", .{batch1.mul(ram_ra_current_claim).toBytes()});
+                            dbg("    batch2*claim2 = {any}\n", .{batch2.mul(lookups_claim).toBytes()});
+                            dbg("    regs_val_current_claim = {x}\n", .{regs_val_current_claim.toBytesBE()[16..32].*});
+                            dbg("    ram_ra_current_claim   = {x}\n", .{ram_ra_current_claim.toBytesBE()[16..32].*});
+                            dbg("    lookups_claim          = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                        }
 
                         // Compute what the hint SHOULD be if coefficients are correct:
                         // hint_expected = p(0) + p(1) = 2*c0 + c1 + c2 + ... + c_d
@@ -5947,8 +6331,10 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                         for (1..combined_coeffs.len) |i| {
                             hint_expected = hint_expected.add(combined_coeffs[i]);
                         }
-                        dbg("  hint_expected (2*c0+c1+c2+...) = {any}\n", .{hint_expected.toBytes()});
-                        dbg("  hint == hint_expected: {}\n", .{current_batched_claim.eql(hint_expected)});
+                        if (comptime debug_verbose) {
+                            dbg("  hint_expected (2*c0+c1+c2+...) = {any}\n", .{hint_expected.toBytes()});
+                            dbg("  hint == hint_expected: {}\n", .{current_batched_claim.eql(hint_expected)});
+                        }
                     }
 
                     // CRITICAL: Update current_batched_claim by evaluating the batched polynomial
@@ -5971,12 +6357,14 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     }
 
                     // Per-round tracking (matches Jolt verifier's [S5V] output)
-                    dbg("  [S5P] R{} challenge={x} new_e={x} degree={}\n", .{
-                        round,
-                        challenge.toBytes()[0..16].*,
-                        current_batched_claim.toBytes()[0..16].*,
-                        combined_coeffs.len - 1,
-                    });
+                    if (comptime debug_verbose) {
+                        dbg("  [S5P] R{} challenge={x} new_e={x} degree={}\n", .{
+                            round,
+                            challenge.toBytes()[0..16].*,
+                            current_batched_claim.toBytes()[0..16].*,
+                            combined_coeffs.len - 1,
+                        });
+                    }
 
                     // Skip the standard compression/serialization below
                     // Bind the challenge for RegistersValEvaluation if active
@@ -6044,14 +6432,18 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                 }
                             }
 
-                            dbg("[STAGE5 CYCLE BIND R{}] cycle_round={}, challenge={x}\n", .{
-                                round,
-                                cycle_round,
-                                challenge.toBytesBE()[16..32].*,
-                            });
-                            dbg("  eq_raf_bound={x}\n", .{eq_raf_bound.toBytesBE()[16..32].*});
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 CYCLE BIND R{}] cycle_round={}, challenge={x}\n", .{
+                                    round,
+                                    cycle_round,
+                                    challenge.toBytesBE()[16..32].*,
+                                });
+                                dbg("  eq_raf_bound={x}\n", .{eq_raf_bound.toBytesBE()[16..32].*});
+                            }
                             if (ram_access_count > 0) {
-                                dbg("  eq_cycle_bound[0]={x}\n", .{eq_cycle_bound[0].toBytesBE()[16..32].*});
+                                if (comptime debug_verbose) {
+                                    dbg("  eq_cycle_bound[0]={x}\n", .{eq_cycle_bound[0].toBytesBE()[16..32].*});
+                                }
                             }
 
                             // CRITICAL FIX: Bind P/Q arrays for Instance 1 PhaseCycle
@@ -6106,10 +6498,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     }
                                 }
 
-                                dbg("[STAGE5 CYCLE BIND R{}] Bound P/Q arrays: half_len={}\n", .{
-                                    round,
-                                    half_len,
-                                });
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 CYCLE BIND R{}] Bound P/Q arrays: half_len={}\n", .{
+                                        round,
+                                        half_len,
+                                    });
+                                }
                             } else {
                                 // PhaseCycle2: bind H_prime and eq_hi arrays
                                 const suffix_round = cycle_round - prefix_n_vars;
@@ -6151,10 +6545,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                                     }
                                 }
 
-                                dbg("[STAGE5 CYCLE BIND R{}] Bound H'/eq_hi arrays: half_len={}\n", .{
-                                    round,
-                                    half_len,
-                                });
+                                if (comptime debug_verbose) {
+                                    dbg("[STAGE5 CYCLE BIND R{}] Bound H'/eq_hi arrays: half_len={}\n", .{
+                                        round,
+                                        half_len,
+                                    });
+                                }
                             }
 
                             // CRITICAL: Update Instance 1 claim after binding
@@ -6172,10 +6568,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             const r2 = challenge.mul(challenge);
                             ram_ra_current_claim = c0_inst1.add(c1_inst1.mulHiBigIntU128(challenge.limbs)).add(c2_inst1.mul(r2));
 
-                            dbg("[STAGE5 INST1 CLAIM] Round {}: new_claim={x}\n", .{
-                                round,
-                                ram_ra_current_claim.toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("[STAGE5 INST1 CLAIM] Round {}: new_claim={x}\n", .{
+                                    round,
+                                    ram_ra_current_claim.toBytesBE()[16..32].*,
+                                });
+                            }
                         }
                     }
 
@@ -6206,13 +6604,15 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print current_scalar update
                     if (lookups_round < 3 or lookups_round >= n_cycle_vars - 1) {
-                        dbg("[STAGE5 CYCLE] round={}, lookups_round={}\n", .{ round, lookups_round });
-                        dbg("  w_i (r_reduction[{}]) = {x}\n", .{ n_cycle_vars - 1 - lookups_round, w_i.toBytesBE()[16..32].* });
-                        dbg("  challenge limbs[2..4] = {x:0>16}{x:0>16}\n", .{ challenge.limbs[2], challenge.limbs[3] });
-                        dbg("  prod_w_r = {x}\n", .{ prod_w_r.toBytesBE()[16..32].* });
-                        dbg("  one_minus_r = {x}\n", .{ one_minus_r_scalar.toBytesBE()[16..32].* });
-                        dbg("  eq_factor = {x}\n", .{ eq_factor.toBytesBE()[16..32].* });
-                        dbg("  current_scalar = {x}\n", .{ lookups_current_scalar.toBytesBE()[16..32].* });
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE] round={}, lookups_round={}\n", .{ round, lookups_round });
+                            dbg("  w_i (r_reduction[{}]) = {x}\n", .{ n_cycle_vars - 1 - lookups_round, w_i.toBytesBE()[16..32].* });
+                            dbg("  challenge limbs[2..4] = {x:0>16}{x:0>16}\n", .{ challenge.limbs[2], challenge.limbs[3] });
+                            dbg("  prod_w_r = {x}\n", .{ prod_w_r.toBytesBE()[16..32].* });
+                            dbg("  one_minus_r = {x}\n", .{ one_minus_r_scalar.toBytesBE()[16..32].* });
+                            dbg("  eq_factor = {x}\n", .{ eq_factor.toBytesBE()[16..32].* });
+                            dbg("  current_scalar = {x}\n", .{ lookups_current_scalar.toBytesBE()[16..32].* });
+                        }
                     }
 
                     // Bind the per-chunk ra weights
@@ -6221,15 +6621,19 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     }
                     // Debug: show ra_chunk values before/after binding
                     if (lookups_round == 0) {
-                        dbg("[STAGE5 CYCLE] ra_chunks before first binding (round=128):\n", .{});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 CYCLE] ra_chunks before first binding (round=128):\n", .{});
+                        }
                         for (0..@min(4, ra_num_chunks)) |c| {
-                            dbg("  ra_chunk[{}][0:4] = [{x}, {x}, {x}, {x}]\n", .{
-                                c,
-                                ra_chunk_weights[c][0].toBytesBE()[16..32].*,
-                                ra_chunk_weights[c][1].toBytesBE()[16..32].*,
-                                ra_chunk_weights[c][2].toBytesBE()[16..32].*,
-                                ra_chunk_weights[c][3].toBytesBE()[16..32].*,
-                            });
+                            if (comptime debug_verbose) {
+                                dbg("  ra_chunk[{}][0:4] = [{x}, {x}, {x}, {x}]\n", .{
+                                    c,
+                                    ra_chunk_weights[c][0].toBytesBE()[16..32].*,
+                                    ra_chunk_weights[c][1].toBytesBE()[16..32].*,
+                                    ra_chunk_weights[c][2].toBytesBE()[16..32].*,
+                                    ra_chunk_weights[c][3].toBytesBE()[16..32].*,
+                                });
+                            }
                         }
                     }
 
@@ -6253,14 +6657,18 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     // Debug: print challenges for cycle rounds (128-135)
                     if (round >= LOOKUPS_LOG_K) {
-                        dbg("[STAGE5 ROUND {}] challenge={x}\n", .{
-                            round,
-                            challenge.toBytesBE()[16..32].*,
-                        });
-                        dbg("  new_batched_claim = {x}\n", .{current_batched_claim.toBytesBE()[16..32].*});
-                        dbg("  new_lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("[STAGE5 ROUND {}] challenge={x}\n", .{
+                                round,
+                                challenge.toBytesBE()[16..32].*,
+                            });
+                            dbg("  new_batched_claim = {x}\n", .{current_batched_claim.toBytesBE()[16..32].*});
+                            dbg("  new_lookups_claim = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                        }
                         // Debug: print eq_evals[0] after binding
-                        dbg("  eq_evals[0] after bind = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
+                        if (comptime debug_verbose) {
+                            dbg("  eq_evals[0] after bind = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
+                        }
 
                         // CRITICAL DIAGNOSTIC: Compare lookups_claim with bound array computation
                         // After binding, compute: current_scalar * Σ_j (eq_prefix(j) * Π_c ra_c[j] * cv[j])
@@ -6277,9 +6685,11 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                             bound_array_sum = bound_array_sum.add(bj_eq.mul(bj_ra).mul(lookups_combined_vals[bj]));
                         }
                         bound_array_sum = bound_array_sum.mul(lookups_current_scalar);
-                        dbg("  BOUND_ARRAY_SUM = {x}\n", .{bound_array_sum.toBytesBE()[16..32].*});
-                        dbg("  lookups_claim   = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
-                        dbg("  BOUND==CLAIM: {}\n", .{bound_array_sum.eql(lookups_claim)});
+                        if (comptime debug_verbose) {
+                            dbg("  BOUND_ARRAY_SUM = {x}\n", .{bound_array_sum.toBytesBE()[16..32].*});
+                            dbg("  lookups_claim   = {x}\n", .{lookups_claim.toBytesBE()[16..32].*});
+                            dbg("  BOUND==CLAIM: {}\n", .{bound_array_sum.eql(lookups_claim)});
+                        }
                     }
 
                     continue; // Skip the rest of the loop (we handled everything)
@@ -6287,19 +6697,23 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             }
 
             // Debug: print final batched claim (this is output_claim from verifier's perspective)
-            dbg("[STAGE5] Final batched claim (output_claim) = {any}\n", .{current_batched_claim.toBytesBE()});
-            dbg("[STAGE5] Final lookups_current_scalar (should = eq_eval_r_reduction) = {x}\n", .{lookups_current_scalar.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Final batched claim (output_claim) = {any}\n", .{current_batched_claim.toBytesBE()});
+                dbg("[STAGE5] Final lookups_current_scalar (should = eq_eval_r_reduction) = {x}\n", .{lookups_current_scalar.toBytesBE()[16..32].*});
+            }
 
             // DEBUG: Print each instance's final claim value
             // The verifier computes expected = batch0*inst0_eval + batch1*inst1_eval + batch2*inst2_eval
             // The prover's output_claim should equal this.
-            dbg("[STAGE5 FINAL CLAIMS] Individual instance final values:\n", .{});
-            dbg("  regs_val_current_claim (Instance 0) = {any}\n", .{regs_val_current_claim.toBytes()});
-            dbg("  ram_ra_current_claim (Instance 1) = {any}\n", .{ram_ra_current_claim.toBytes()});
-            dbg("  lookups_claim (Instance 2) = {any}\n", .{lookups_claim.toBytes()});
-            dbg("  batch0*inst0 (LE) = {any}\n", .{batch0.mul(regs_val_current_claim).toBytes()});
-            dbg("  batch1*inst1 (LE) = {any}\n", .{batch1.mul(ram_ra_current_claim).toBytes()});
-            dbg("  batch2*inst2 (LE) = {any}\n", .{batch2.mul(lookups_claim).toBytes()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 FINAL CLAIMS] Individual instance final values:\n", .{});
+                dbg("  regs_val_current_claim (Instance 0) = {any}\n", .{regs_val_current_claim.toBytes()});
+                dbg("  ram_ra_current_claim (Instance 1) = {any}\n", .{ram_ra_current_claim.toBytes()});
+                dbg("  lookups_claim (Instance 2) = {any}\n", .{lookups_claim.toBytes()});
+                dbg("  batch0*inst0 (LE) = {any}\n", .{batch0.mul(regs_val_current_claim).toBytes()});
+                dbg("  batch1*inst1 (LE) = {any}\n", .{batch1.mul(ram_ra_current_claim).toBytes()});
+                dbg("  batch2*inst2 (LE) = {any}\n", .{batch2.mul(lookups_claim).toBytes()});
+            }
 
             // Print the chain values so we can compare with Jolt verifier
             if (comptime debug_verbose) {
@@ -6319,17 +6733,21 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 print("[ZOLT S5 CHAIN] sum==batched = {}\n", .{recon.eql(current_batched_claim)});
             }
             const recon = batch0.mul(regs_val_current_claim).add(batch1.mul(ram_ra_current_claim)).add(batch2.mul(lookups_claim));
-            dbg("  batch0*inst0 + batch1*inst1 + batch2*inst2 = {any}\n", .{recon.toBytes()});
-            dbg("  current_batched_claim = {any}\n", .{current_batched_claim.toBytes()});
-            dbg("  reconstruction matches output_claim: {}\n", .{recon.eql(current_batched_claim)});
+            if (comptime debug_verbose) {
+                dbg("  batch0*inst0 + batch1*inst1 + batch2*inst2 = {any}\n", .{recon.toBytes()});
+                dbg("  current_batched_claim = {any}\n", .{current_batched_claim.toBytes()});
+                dbg("  reconstruction matches output_claim: {}\n", .{recon.eql(current_batched_claim)});
+            }
 
             // CRITICAL: Derive correct Instance 2 claim from batched output
             // The batched output_claim is CORRECT (S5P==S5V). Individual claims for
             // inst0 and inst1 are also correct. So we can derive the TRUE inst2 claim.
             const correct_inst2_from_batched = current_batched_claim.sub(batch0.mul(regs_val_current_claim)).sub(batch1.mul(ram_ra_current_claim)).mul(batch2_inv);
-            dbg("  [DRIFT CHECK] lookups_claim (tracked)     = {any}\n", .{lookups_claim.toBytes()});
-            dbg("  [DRIFT CHECK] correct_inst2 (from batch)  = {any}\n", .{correct_inst2_from_batched.toBytes()});
-            dbg("  [DRIFT CHECK] drift detected: {}\n", .{!lookups_claim.eql(correct_inst2_from_batched)});
+            if (comptime debug_verbose) {
+                dbg("  [DRIFT CHECK] lookups_claim (tracked)     = {any}\n", .{lookups_claim.toBytes()});
+                dbg("  [DRIFT CHECK] correct_inst2 (from batch)  = {any}\n", .{correct_inst2_from_batched.toBytes()});
+                dbg("  [DRIFT CHECK] drift detected: {}\n", .{!lookups_claim.eql(correct_inst2_from_batched)});
+            }
 
             // =================================================================
             // BRUTE FORCE Instance 1 expected output claim
@@ -6381,14 +6799,16 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                 const bf_expected_inst1 = bf_eq_combined.mul(bf_ra_claim);
 
-                dbg("[BRUTE FORCE INST1] eq_cycle_raf = {x}\n", .{eq_cycle_raf_red.toBytesBE()[16..32].*});
-                dbg("[BRUTE FORCE INST1] eq_cycle_rw = {x}\n", .{eq_cycle_rw_red.toBytesBE()[16..32].*});
-                dbg("[BRUTE FORCE INST1] eq_cycle_val = {x}\n", .{eq_cycle_val_red.toBytesBE()[16..32].*});
-                dbg("[BRUTE FORCE INST1] eq_combined = {x}\n", .{bf_eq_combined.toBytesBE()[16..32].*});
-                dbg("[BRUTE FORCE INST1] ra_claim_reduced = {x}\n", .{bf_ra_claim.toBytesBE()[16..32].*});
-                dbg("[BRUTE FORCE INST1] expected (eq_combined * ra_reduced) = {any}\n", .{bf_expected_inst1.toBytes()});
-                dbg("[BRUTE FORCE INST1] prover tracked ram_ra_current_claim = {any}\n", .{ram_ra_current_claim.toBytes()});
-                dbg("[BRUTE FORCE INST1] match: {}\n", .{bf_expected_inst1.eql(ram_ra_current_claim)});
+                if (comptime debug_verbose) {
+                    dbg("[BRUTE FORCE INST1] eq_cycle_raf = {x}\n", .{eq_cycle_raf_red.toBytesBE()[16..32].*});
+                    dbg("[BRUTE FORCE INST1] eq_cycle_rw = {x}\n", .{eq_cycle_rw_red.toBytesBE()[16..32].*});
+                    dbg("[BRUTE FORCE INST1] eq_cycle_val = {x}\n", .{eq_cycle_val_red.toBytesBE()[16..32].*});
+                    dbg("[BRUTE FORCE INST1] eq_combined = {x}\n", .{bf_eq_combined.toBytesBE()[16..32].*});
+                    dbg("[BRUTE FORCE INST1] ra_claim_reduced = {x}\n", .{bf_ra_claim.toBytesBE()[16..32].*});
+                    dbg("[BRUTE FORCE INST1] expected (eq_combined * ra_reduced) = {any}\n", .{bf_expected_inst1.toBytes()});
+                    dbg("[BRUTE FORCE INST1] prover tracked ram_ra_current_claim = {any}\n", .{ram_ra_current_claim.toBytes()});
+                    dbg("[BRUTE FORCE INST1] match: {}\n", .{bf_expected_inst1.eql(ram_ra_current_claim)});
+                }
             }
 
             // Get final opening claims from the folded polynomials
@@ -6397,21 +6817,25 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             const regs_val_lt_claim = lt_evals[0];
             const regs_final_product = regs_val_inc_claim.mul(regs_val_wa_claim).mul(regs_val_lt_claim);
 
-            dbg("[STAGE5] Final opening claims:\n", .{});
-            dbg("  regs_val_inc_claim = {any}\n", .{regs_val_inc_claim.toBytesBE()});
-            dbg("  regs_val_wa_claim = {any}\n", .{regs_val_wa_claim.toBytesBE()});
-            dbg("  regs_val_lt_claim (lt[0] after binding) = {any}\n", .{regs_val_lt_claim.toBytesBE()});
-            dbg("  regs_final_product (inc*wa*lt) = {any}\n", .{regs_final_product.toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Final opening claims:\n", .{});
+                dbg("  regs_val_inc_claim = {any}\n", .{regs_val_inc_claim.toBytesBE()});
+                dbg("  regs_val_wa_claim = {any}\n", .{regs_val_wa_claim.toBytesBE()});
+                dbg("  regs_val_lt_claim (lt[0] after binding) = {any}\n", .{regs_val_lt_claim.toBytesBE()});
+                dbg("  regs_final_product (inc*wa*lt) = {any}\n", .{regs_final_product.toBytesBE()});
+            }
 
             // Compute what the verifier would compute for LT(r_normalized, r_cycle)
             // r_normalized = reversed challenges (BIG_ENDIAN)
             // The last 8 challenges are for RegistersValEvaluation
             const regs_challenges = challenges[(max_num_rounds - regs_val_num_rounds)..];
-            dbg("[STAGE5] Computing verifier's LT(r_normalized, r_cycle):\n", .{});
-            dbg("  regs_challenges[0] = {any}\n", .{regs_challenges[0].toBytesBE()[0..8]});
-            dbg("  regs_challenges[7] = {any}\n", .{regs_challenges[7].toBytesBE()[0..8]});
-            dbg("  r_cycle_regs[0] = {any}\n", .{r_cycle_regs[0].toBytesBE()[0..8]});
-            dbg("  r_cycle_regs[7] = {any}\n", .{r_cycle_regs[7].toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5] Computing verifier's LT(r_normalized, r_cycle):\n", .{});
+                dbg("  regs_challenges[0] = {any}\n", .{regs_challenges[0].toBytesBE()[0..8]});
+                dbg("  regs_challenges[7] = {any}\n", .{regs_challenges[7].toBytesBE()[0..8]});
+                dbg("  r_cycle_regs[0] = {any}\n", .{r_cycle_regs[0].toBytesBE()[0..8]});
+                dbg("  r_cycle_regs[7] = {any}\n", .{r_cycle_regs[7].toBytesBE()[0..8]});
+            }
 
             // Compute LT(r_normalized, r_cycle) like the verifier does
             // r_normalized = [c7, c6, c5, c4, c3, c2, c1, c0] (reversed challenges)
@@ -6428,12 +6852,16 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 const xy = x_i.mul(y_i);
                 eq_term = eq_term.mul(F.one().sub(x_i).sub(y_i).add(xy).add(xy));
             }
-            dbg("  LT_verifier (what verifier computes) = {any}\n", .{lt_verifier.toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("  LT_verifier (what verifier computes) = {any}\n", .{lt_verifier.toBytesBE()});
+            }
 
             // The verifier expects: expected_output_claim = inc_claim * wa_claim * LT_verifier
             const expected_product = regs_val_inc_claim.mul(regs_val_wa_claim).mul(lt_verifier);
-            dbg("  expected_product (inc*wa*LT_verifier) = {any}\n", .{expected_product.toBytesBE()});
-            dbg("  Match: {}\n", .{regs_final_product.eql(expected_product)});
+            if (comptime debug_verbose) {
+                dbg("  expected_product (inc*wa*LT_verifier) = {any}\n", .{expected_product.toBytesBE()});
+                dbg("  Match: {}\n", .{regs_final_product.eql(expected_product)});
+            }
 
             // Compute LookupsReadRaf opening claims
             //
@@ -6488,14 +6916,16 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                 print("[S5 FINAL] combined_val[0] = {any}\n", .{lookups_combined_vals[0].toBytes()});
             }
 
-            dbg("[STAGE5 LOOKUPS] Computing opening claims:\n", .{});
-            dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()[0..8]});
-            dbg("  lookups_output_claim (eq*ra_w0*combined) = {any}\n", .{lookups_output_claim.toBytesBE()});
-            dbg("  lookups_claim (tracked Instance 2) = {any}\n", .{lookups_claim.toBytes()});
-            dbg("  lookups_eq_evals[0] = {any}\n", .{lookups_eq_evals[0].toBytesBE()[0..8]});
-            dbg("  lookups_combined_vals[0] = {any}\n", .{lookups_combined_vals[0].toBytes()});
-            dbg("  lookups_current_scalar = {any}\n", .{lookups_current_scalar.toBytes()});
-            dbg("  lookups_combined_vals[0] = {any}\n", .{lookups_combined_vals[0].toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] Computing opening claims:\n", .{});
+                dbg("  lookups_input = {any}\n", .{lookups_input.toBytesBE()[0..8]});
+                dbg("  lookups_output_claim (eq*ra_w0*combined) = {any}\n", .{lookups_output_claim.toBytesBE()});
+                dbg("  lookups_claim (tracked Instance 2) = {any}\n", .{lookups_claim.toBytes()});
+                dbg("  lookups_eq_evals[0] = {any}\n", .{lookups_eq_evals[0].toBytesBE()[0..8]});
+                dbg("  lookups_combined_vals[0] = {any}\n", .{lookups_combined_vals[0].toBytes()});
+                dbg("  lookups_current_scalar = {any}\n", .{lookups_current_scalar.toBytes()});
+                dbg("  lookups_combined_vals[0] = {any}\n", .{lookups_combined_vals[0].toBytesBE()[0..8]});
+            }
 
             // Compute eq(r_reduction, r_cycle_prime)
             // r_reduction is from Stage 3 InstructionClaimReduction (BIG_ENDIAN)
@@ -6512,22 +6942,36 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
             const eq_r_reduction = computeEqPolynomial(F, r_reduction, r_cycle_prime_be);
 
-            dbg("  r_reduction[0..8] (8 elements):\n", .{});
-            for (0..n_cycle_vars) |i| {
-                dbg("    r_reduction[{}] = {x}\n", .{ i, r_reduction[i].toBytesBE()[16..32].* });
+            if (comptime debug_verbose) {
+                dbg("  r_reduction[0..8] (8 elements):\n", .{});
             }
-            dbg("  r_cycle_prime_be[0..8] (8 elements):\n", .{});
             for (0..n_cycle_vars) |i| {
-                dbg("    r_cycle_prime_be[{}] = {x}\n", .{ i, r_cycle_prime_be[i].toBytesBE()[16..32].* });
+                if (comptime debug_verbose) {
+                    dbg("    r_reduction[{}] = {x}\n", .{ i, r_reduction[i].toBytesBE()[16..32].* });
+                }
             }
-            dbg("  eq_r_reduction (verifier computes) = {x}\n", .{eq_r_reduction.toBytesBE()[16..32].*});
-            dbg("  eq_evals[0] (from sumcheck) = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
-            dbg("  lookups_current_scalar (should equal eq_r_reduction) = {x}\n", .{lookups_current_scalar.toBytesBE()[16..32].*});
+            if (comptime debug_verbose) {
+                dbg("  r_cycle_prime_be[0..8] (8 elements):\n", .{});
+            }
+            for (0..n_cycle_vars) |i| {
+                if (comptime debug_verbose) {
+                    dbg("    r_cycle_prime_be[{}] = {x}\n", .{ i, r_cycle_prime_be[i].toBytesBE()[16..32].* });
+                }
+            }
+            if (comptime debug_verbose) {
+                dbg("  eq_r_reduction (verifier computes) = {x}\n", .{eq_r_reduction.toBytesBE()[16..32].*});
+                dbg("  eq_evals[0] (from sumcheck) = {x}\n", .{lookups_eq_evals[0].toBytesBE()[16..32].*});
+                dbg("  lookups_current_scalar (should equal eq_r_reduction) = {x}\n", .{lookups_current_scalar.toBytesBE()[16..32].*});
+            }
 
             // Debug: print first few r_address_prime values
-            dbg("[STAGE5 FINAL] r_address_prime[0..4] (sumcheck challenges 0-3):\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 FINAL] r_address_prime[0..4] (sumcheck challenges 0-3):\n", .{});
+            }
             for (0..4) |i| {
-                dbg("  r_address_prime[{}] = {x}\n", .{ i, r_address_prime[i].toBytesBE()[16..32].* });
+                if (comptime debug_verbose) {
+                    dbg("  r_address_prime[{}] = {x}\n", .{ i, r_address_prime[i].toBytesBE()[16..32].* });
+                }
             }
 
             // Compute operand polynomial evaluations at r_address_prime
@@ -6535,10 +6979,12 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             const right_op_eval = evaluateRightOperand(F, r_address_prime);
             const identity_eval = evaluateIdentity(F, r_address_prime);
 
-            dbg("  left_op_eval (full) = {x}\n", .{left_op_eval.toBytesBE()[16..32].*});
-            dbg("  right_op_eval (full) = {x}\n", .{right_op_eval.toBytesBE()[16..32].*});
-            dbg("  identity_eval (full) = {x}\n", .{identity_eval.toBytesBE()[16..32].*});
-            dbg("  gamma_lookups_raf = {any}\n", .{gamma_lookups_raf.toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("  left_op_eval (full) = {x}\n", .{left_op_eval.toBytesBE()[16..32].*});
+                dbg("  right_op_eval (full) = {x}\n", .{right_op_eval.toBytesBE()[16..32].*});
+                dbg("  identity_eval (full) = {x}\n", .{identity_eval.toBytesBE()[16..32].*});
+                dbg("  gamma_lookups_raf = {any}\n", .{gamma_lookups_raf.toBytesBE()[0..8]});
+            }
 
             // CORRECT APPROACH: Compute opening claims from the bound polynomials
             //
@@ -6560,30 +7006,42 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             }
 
             // Debug: print ra chunk claims (FULL 32 bytes for comparison with Jolt)
-            dbg("[STAGE5 LOOKUPS] ra_chunk claims (FULL 32 bytes LE for Jolt comparison):\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] ra_chunk claims (FULL 32 bytes LE for Jolt comparison):\n", .{});
+            }
             var ra_product = F.one();
             for (0..lookups_ra_d) |i| {
                 const le_bytes = ra_chunks[i].toBytes();
-                dbg("  ra_chunks[{}] LE = {any}\n", .{ i, le_bytes });
+                if (comptime debug_verbose) {
+                    dbg("  ra_chunks[{}] LE = {any}\n", .{ i, le_bytes });
+                }
                 ra_product = ra_product.mul(ra_chunks[i]);
             }
             const ra_product_le = ra_product.toBytes();
-            dbg("  ra_product FULL LE = {any}\n", .{ra_product_le});
-            dbg("  lookups_ra_weights[0] = {any}\n", .{lookups_ra_weights[0].toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("  ra_product FULL LE = {any}\n", .{ra_product_le});
+                dbg("  lookups_ra_weights[0] = {any}\n", .{lookups_ra_weights[0].toBytesBE()[0..8]});
+            }
 
             // Check lookups_current_scalar * ra_product * combined_vals[0]
             const scalar_ra_combined = lookups_current_scalar.mul(ra_product).mul(lookups_combined_vals[0]);
-            dbg("  scalar*ra_product*combined = {any}\n", .{scalar_ra_combined.toBytes()});
-            dbg("  lookups_claim (tracked)    = {any}\n", .{lookups_claim.toBytes()});
-            dbg("  scalar*ra_product*combined == lookups_claim: {}\n", .{scalar_ra_combined.eql(lookups_claim)});
+            if (comptime debug_verbose) {
+                dbg("  scalar*ra_product*combined = {any}\n", .{scalar_ra_combined.toBytes()});
+                dbg("  lookups_claim (tracked)    = {any}\n", .{lookups_claim.toBytes()});
+                dbg("  scalar*ra_product*combined == lookups_claim: {}\n", .{scalar_ra_combined.eql(lookups_claim)});
+            }
 
             // Verify ra_product == lookups_ra_weights[0]
             const match_after = ra_product.eql(lookups_ra_weights[0]);
-            dbg("  ra_product == lookups_ra_weights[0] (after all binding): {}\n", .{match_after});
+            if (comptime debug_verbose) {
+                dbg("  ra_product == lookups_ra_weights[0] (after all binding): {}\n", .{match_after});
+            }
             if (!match_after) {
-                dbg("  WARNING: ra_product and lookups_ra_weights[0] don't match after binding!\n", .{});
-                dbg("  This is expected - binding the product != product of bindings\n", .{});
-                dbg("  The correct ra_claim should be the PRODUCT of the bound chunk values.\n", .{});
+                if (comptime debug_verbose) {
+                    dbg("  WARNING: ra_product and lookups_ra_weights[0] don't match after binding!\n", .{});
+                    dbg("  This is expected - binding the product != product of bindings\n", .{});
+                    dbg("  The correct ra_claim should be the PRODUCT of the bound chunk values.\n", .{});
+                }
             }
 
             // Print table index histogram for comparison with Jolt
@@ -6659,10 +7117,14 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             }
 
             // Debug: print non-zero table flags
-            dbg("[STAGE5 LOOKUPS] Non-zero table flags (FULL LE):\n", .{});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] Non-zero table flags (FULL LE):\n", .{});
+            }
             for (0..num_lookup_tables) |i| {
                 if (!table_flags[i].eql(F.zero())) {
-                    dbg("  table_flags[{}] = {any}\n", .{ i, table_flags[i].toBytes() });
+                    if (comptime debug_verbose) {
+                        dbg("  table_flags[{}] = {any}\n", .{ i, table_flags[i].toBytes() });
+                    }
                 }
             }
 
@@ -6675,7 +7137,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
                     computed_raf_flag = computed_raf_flag.add(eq_j);
                 }
             }
-            dbg("[STAGE5 LOOKUPS] raf_flag (identity path sum) = {any}\n", .{computed_raf_flag.toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 LOOKUPS] raf_flag (identity path sum) = {any}\n", .{computed_raf_flag.toBytesBE()[0..8]});
+            }
 
             // Verify the opening claims match the sumcheck output
             // expected = eq_r_reduction * ra_product * (val_claim + gamma * raf_claim)
@@ -6719,68 +7183,92 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             // The prover's combined_val polynomial should encode: table_val + gamma * raf_val
             // After all cycle round binding, combined_vals[0] should equal val_claim + gamma * raf_claim
             const verifier_combined = val_claim.add(gamma_lookups_raf.mul(raf_claim));
-            dbg("\n  === CRITICAL COMPARISON ===\n", .{});
-            dbg("  combined_vals[0] (bound polynomial) FULL LE = {any}\n", .{lookups_combined_vals[0].toBytes()});
-            dbg("  val+gamma*raf   (from opening claims) FULL LE = {any}\n", .{verifier_combined.toBytes()});
-            dbg("  combined_vals[0] == val+gamma*raf: {}\n", .{lookups_combined_vals[0].eql(verifier_combined)});
+            if (comptime debug_verbose) {
+                dbg("\n  === CRITICAL COMPARISON ===\n", .{});
+                dbg("  combined_vals[0] (bound polynomial) FULL LE = {any}\n", .{lookups_combined_vals[0].toBytes()});
+                dbg("  val+gamma*raf   (from opening claims) FULL LE = {any}\n", .{verifier_combined.toBytes()});
+                dbg("  combined_vals[0] == val+gamma*raf: {}\n", .{lookups_combined_vals[0].eql(verifier_combined)});
+            }
             if (!lookups_combined_vals[0].eql(verifier_combined)) {
                 // They differ! This means the bound polynomial disagrees with opening claims.
                 // Try other hypotheses:
                 // 1. Maybe combined_vals includes ra_product already?
                 const cv_div_ra = if (!ra_product.eql(F.zero())) lookups_combined_vals[0].mul(ra_product.inverse().?) else F.zero();
-                dbg("  combined_vals[0] / ra_product = {any}\n", .{cv_div_ra.toBytes()});
-                dbg("  cv/ra == val+gamma*raf: {}\n", .{cv_div_ra.eql(verifier_combined)});
+                if (comptime debug_verbose) {
+                    dbg("  combined_vals[0] / ra_product = {any}\n", .{cv_div_ra.toBytes()});
+                    dbg("  cv/ra == val+gamma*raf: {}\n", .{cv_div_ra.eql(verifier_combined)});
+                }
 
                 // 2. Maybe combined_vals = ra_product * (val + gamma * raf)?
                 const ra_times_combined = ra_product.mul(verifier_combined);
-                dbg("  ra_product * (val+gamma*raf) = {any}\n", .{ra_times_combined.toBytes()});
-                dbg("  ra*(val+gamma*raf) == combined_vals[0]: {}\n", .{ra_times_combined.eql(lookups_combined_vals[0])});
+                if (comptime debug_verbose) {
+                    dbg("  ra_product * (val+gamma*raf) = {any}\n", .{ra_times_combined.toBytes()});
+                    dbg("  ra*(val+gamma*raf) == combined_vals[0]: {}\n", .{ra_times_combined.eql(lookups_combined_vals[0])});
+                }
 
                 // 3. Compute what correct_inst2 / (eq_r_reduction * ra_product) gives
                 // This should be combined_vals[0] if lookups_output_claim = eq*ra*cv
                 if (!eq_r_reduction.eql(F.zero()) and !ra_product.eql(F.zero())) {
                     const implied_cv = correct_inst2_from_batched.mul(eq_r_reduction.inverse().?).mul(ra_product.inverse().?);
-                    dbg("  correct_inst2 / (eq*ra) = {any}\n", .{implied_cv.toBytes()});
-                    dbg("  implied_cv == combined_vals[0]: {}\n", .{implied_cv.eql(lookups_combined_vals[0])});
-                    dbg("  implied_cv == val+gamma*raf: {}\n", .{implied_cv.eql(verifier_combined)});
+                    if (comptime debug_verbose) {
+                        dbg("  correct_inst2 / (eq*ra) = {any}\n", .{implied_cv.toBytes()});
+                        dbg("  implied_cv == combined_vals[0]: {}\n", .{implied_cv.eql(lookups_combined_vals[0])});
+                        dbg("  implied_cv == val+gamma*raf: {}\n", .{implied_cv.eql(verifier_combined)});
+                    }
                 }
 
                 // 4. Compute correct_inst2 / (lookups_current_scalar * ra_product)
                 // This might be the true combined_val if current_scalar != eq_r_reduction
                 if (!lookups_current_scalar.eql(F.zero()) and !ra_product.eql(F.zero())) {
                     const implied_cv2 = correct_inst2_from_batched.mul(lookups_current_scalar.inverse().?).mul(ra_product.inverse().?);
-                    dbg("  correct_inst2 / (scalar*ra) = {any}\n", .{implied_cv2.toBytes()});
-                    dbg("  implied_cv2 == combined_vals[0]: {}\n", .{implied_cv2.eql(lookups_combined_vals[0])});
-                    dbg("  implied_cv2 == val+gamma*raf: {}\n", .{implied_cv2.eql(verifier_combined)});
+                    if (comptime debug_verbose) {
+                        dbg("  correct_inst2 / (scalar*ra) = {any}\n", .{implied_cv2.toBytes()});
+                        dbg("  implied_cv2 == combined_vals[0]: {}\n", .{implied_cv2.eql(lookups_combined_vals[0])});
+                        dbg("  implied_cv2 == val+gamma*raf: {}\n", .{implied_cv2.eql(verifier_combined)});
+                    }
                 }
 
                 // 5. Check if eq_r_reduction == lookups_current_scalar
-                dbg("  eq_r_reduction == lookups_current_scalar: {}\n", .{eq_r_reduction.eql(lookups_current_scalar)});
+                if (comptime debug_verbose) {
+                    dbg("  eq_r_reduction == lookups_current_scalar: {}\n", .{eq_r_reduction.eql(lookups_current_scalar)});
+                }
             }
-            dbg("  === END CRITICAL COMPARISON ===\n\n", .{});
+            if (comptime debug_verbose) {
+                dbg("  === END CRITICAL COMPARISON ===\n\n", .{});
+            }
 
             // Compute expected output: eq_r_reduction * ra_product * (val_claim + gamma * raf_claim)
             const expected_output = eq_r_reduction.mul(ra_product).mul(val_claim.add(gamma_lookups_raf.mul(raf_claim)));
-            dbg("  expected_output (eq*ra*(val+gamma*raf)) FULL LE = {any}\n", .{expected_output.toBytes()});
-            dbg("  expected_output last 16 LE = ", .{});
-            for (expected_output.toBytes()[16..32]) |b| dbg("{x:0>2} ", .{b});
-            dbg("\n", .{});
-            dbg("  lookups_output_claim = {any}\n", .{lookups_output_claim.toBytesBE()[0..8]});
-            dbg("  current_batched_claim = {any}\n", .{current_batched_claim.toBytesBE()[0..8]});
+            if (comptime debug_verbose) {
+                dbg("  expected_output (eq*ra*(val+gamma*raf)) FULL LE = {any}\n", .{expected_output.toBytes()});
+                dbg("  expected_output last 16 LE = ", .{});
+                for (expected_output.toBytes()[16..32]) |b| dbg("{x:0>2} ", .{b});
+                dbg("\n", .{});
+                dbg("  lookups_output_claim = {any}\n", .{lookups_output_claim.toBytesBE()[0..8]});
+                dbg("  current_batched_claim = {any}\n", .{current_batched_claim.toBytesBE()[0..8]});
+            }
 
             // Check if expected matches the sumcheck output
-            dbg("  expected_output == lookups_output_claim: {}\n", .{expected_output.eql(lookups_output_claim)});
+            if (comptime debug_verbose) {
+                dbg("  expected_output == lookups_output_claim: {}\n", .{expected_output.eql(lookups_output_claim)});
+            }
 
             // Check if the correct inst2 from batched matches the opening claims
-            dbg("  correct_inst2_from_batched == lookups_output_claim: {}\n", .{correct_inst2_from_batched.eql(lookups_output_claim)});
+            if (comptime debug_verbose) {
+                dbg("  correct_inst2_from_batched == lookups_output_claim: {}\n", .{correct_inst2_from_batched.eql(lookups_output_claim)});
+            }
             if (!correct_inst2_from_batched.eql(lookups_output_claim)) {
-                dbg("  ERROR: correct_inst2_from_batched != lookups_output_claim!\n", .{});
-                dbg("  correct_inst2 = {any}\n", .{correct_inst2_from_batched.toBytes()});
-                dbg("  lookups_output = {any}\n", .{lookups_output_claim.toBytes()});
+                if (comptime debug_verbose) {
+                    dbg("  ERROR: correct_inst2_from_batched != lookups_output_claim!\n", .{});
+                    dbg("  correct_inst2 = {any}\n", .{correct_inst2_from_batched.toBytes()});
+                    dbg("  lookups_output = {any}\n", .{lookups_output_claim.toBytes()});
+                }
                 // Compute ratio for debugging
                 if (!lookups_output_claim.eql(F.zero())) {
                     const ratio = correct_inst2_from_batched.mul(lookups_output_claim.inverse().?);
-                    dbg("  ratio (correct/output) = {any}\n", .{ratio.toBytes()});
+                    if (comptime debug_verbose) {
+                        dbg("  ratio (correct/output) = {any}\n", .{ratio.toBytes()});
+                    }
                 }
 
                 // BRUTE FORCE: Compute true Instance 2 output by summing over trace
@@ -6822,13 +7310,17 @@ pub fn Stage5BatchedProver(comptime F: type) type {
 
                     bf_inst2_output = bf_inst2_output.add(eq_red_j.mul(eq_cyc_j).mul(ra_j).mul(cv_j));
                 }
-                dbg("  BF inst2_output = {any}\n", .{bf_inst2_output.toBytes()});
-                dbg("  BF == lookups_output_claim: {}\n", .{bf_inst2_output.eql(lookups_output_claim)});
-                dbg("  BF == correct_inst2: {}\n", .{bf_inst2_output.eql(correct_inst2_from_batched)});
+                if (comptime debug_verbose) {
+                    dbg("  BF inst2_output = {any}\n", .{bf_inst2_output.toBytes()});
+                    dbg("  BF == lookups_output_claim: {}\n", .{bf_inst2_output.eql(lookups_output_claim)});
+                    dbg("  BF == correct_inst2: {}\n", .{bf_inst2_output.eql(correct_inst2_from_batched)});
+                }
             } else {
-                dbg("  GOOD: correct_inst2_from_batched == lookups_output_claim\n", .{});
-                dbg("  The opening claims are CORRECT. The fix is to use correct_inst2_from_batched\n", .{});
-                dbg("  as the Instance 2 claim when computing the batched expected output.\n", .{});
+                if (comptime debug_verbose) {
+                    dbg("  GOOD: correct_inst2_from_batched == lookups_output_claim\n", .{});
+                    dbg("  The opening claims are CORRECT. The fix is to use correct_inst2_from_batched\n", .{});
+                    dbg("  as the Instance 2 claim when computing the batched expected output.\n", .{});
+                }
             }
 
             // ============================================================
@@ -6839,7 +7331,9 @@ pub fn Stage5BatchedProver(comptime F: type) type {
             // opening point [r_address, r_cycle_reduced].
             // This matches upstream's state.H_prime.final_sumcheck_claim().
             const ram_ra_claim = H_prime[0];
-            dbg("[STAGE5 RAM_RA] ram_ra_claim = H_prime[0] = {x}\n", .{ram_ra_claim.toBytesBE()});
+            if (comptime debug_verbose) {
+                dbg("[STAGE5 RAM_RA] ram_ra_claim = H_prime[0] = {x}\n", .{ram_ra_claim.toBytesBE()});
+            }
 
             return Stage5Result(F){
                 .challenges = challenges,
@@ -7476,14 +7970,18 @@ pub fn evaluateRightOperand(comptime F: type, r: []const F) F {
         result = result.add(term);
         // Debug: print first few and last few iterations
         if (n == 128 and (i < 3 or i >= 61)) {
-            dbg("[RIGHT_OP_DEBUG] i={d}: r[{d}]={x}, power={x}, term={x}, result={x}\n", .{
-                i, idx, r[idx].toBytesBE()[16..32].*, power.toBytesBE()[16..32].*,
-                term.toBytesBE()[16..32].*, result.toBytesBE()[16..32].*,
-            });
+            if (comptime debug_verbose) {
+                dbg("[RIGHT_OP_DEBUG] i={d}: r[{d}]={x}, power={x}, term={x}, result={x}\n", .{
+                    i, idx, r[idx].toBytesBE()[16..32].*, power.toBytesBE()[16..32].*,
+                    term.toBytesBE()[16..32].*, result.toBytesBE()[16..32].*,
+                });
+            }
         }
         power = power.add(power); // power *= 2
     }
-    dbg("[RIGHT_OP_DEBUG] final result = {x}\n", .{result.toBytesBE()[16..32].*});
+    if (comptime debug_verbose) {
+        dbg("[RIGHT_OP_DEBUG] final result = {x}\n", .{result.toBytesBE()[16..32].*});
+    }
     return result;
 }
 
@@ -7502,14 +8000,18 @@ pub fn evaluateIdentity(comptime F: type, r: []const F) F {
         result = result.add(term);
         // Debug: print first few and last few iterations
         if (n == 128 and (i < 4 or i >= 124)) {
-            dbg("[IDENTITY_DEBUG] i={d}: r[{d}]={x}, power={x}, term={x}, result={x}\n", .{
-                i, i, r[i].toBytesBE()[16..32].*, power.toBytesBE()[16..32].*,
-                term.toBytesBE()[16..32].*, result.toBytesBE()[16..32].*,
-            });
+            if (comptime debug_verbose) {
+                dbg("[IDENTITY_DEBUG] i={d}: r[{d}]={x}, power={x}, term={x}, result={x}\n", .{
+                    i, i, r[i].toBytesBE()[16..32].*, power.toBytesBE()[16..32].*,
+                    term.toBytesBE()[16..32].*, result.toBytesBE()[16..32].*,
+                });
+            }
         }
         power = power.add(power); // power *= 2
     }
-    dbg("[IDENTITY_DEBUG] final result = {x}\n", .{result.toBytesBE()[16..32].*});
+    if (comptime debug_verbose) {
+        dbg("[IDENTITY_DEBUG] final result = {x}\n", .{result.toBytesBE()[16..32].*});
+    }
     return result;
 }
 


### PR DESCRIPTION
## Summary
- Wrap all ungated `dbg()` calls and their supporting computation in `if (comptime debug_verbose)` blocks in `stage3_prover.zig` and `stage5_prover.zig`
- Previously, heavy diagnostic loops (opcode counting, sum verification with full instruction decoding, MLE checks) ran unconditionally despite `debug_verbose = false`
- **primes_large: 14,309ms → 12,286ms (14% faster, ~2s saved)**

## Test plan
- [x] Build succeeds with `ReleaseFast`
- [x] fibonacci verified against upstream Jolt verifier
- [x] primes_large verified against upstream Jolt verifier

Relates to #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)