### PR TITLE
perf: parallelize stage setup, RAM init, and sparse register construction

### DIFF
--- a/src/poly/mod.zig
+++ b/src/poly/mod.zig
@@ -327,6 +327,61 @@ pub fn EqPolynomial(comptime F: type) type {
             return result;
         }
 
+        /// Compute eq evaluations with optional parallel inner loops.
+        /// Same as evalsSliceWithScaling but parallelizes large levels via ThreadPool.
+        pub fn evalsSliceWithScalingParallel(comptime FieldType: type, allocator: Allocator, r: []const FieldType, scaling_factor: ?FieldType, pool: ?*@import("../utils/thread_pool.zig").ThreadPool) ![]FieldType {
+            const n = r.len;
+            if (n == 0) {
+                const result = try allocator.alloc(FieldType, 1);
+                result[0] = scaling_factor orelse FieldType.one();
+                return result;
+            }
+
+            const final_size = @as(usize, 1) << @as(u6, @intCast(n));
+            const result = try allocator.alloc(FieldType, final_size);
+
+            @memset(result, FieldType.zero());
+            result[0] = scaling_factor orelse FieldType.one();
+
+            // BE convention: iterate r in reverse
+            var size: usize = 1;
+            var j: usize = n;
+            while (j > 0) {
+                j -= 1;
+                const r_j = r[j];
+
+                if (pool != null and size >= 256) {
+                    const TP = @import("../utils/thread_pool.zig").ThreadPool;
+                    const Ctx = struct {
+                        res: []FieldType,
+                        rj: FieldType,
+                        sz: usize,
+                    };
+                    const ctx = Ctx{ .res = result, .rj = r_j, .sz = size };
+                    const p: *TP = pool.?;
+                    p.parallelForForce(size, ctx, struct {
+                        fn f(c: Ctx, i: usize) void {
+                            const x = c.res[i];
+                            const y = x.mul(c.rj);
+                            c.res[i + c.sz] = y;
+                            c.res[i] = x.sub(y);
+                        }
+                    }.f);
+                } else {
+                    for (0..size) |i| {
+                        const x = result[i];
+                        const y = x.mul(r_j);
+                        result[i + size] = y;
+                        result[i] = x.sub(y);
+                    }
+                }
+
+                size *= 2;
+            }
+
+            return result;
+        }
+
         /// Bind the first variable and reduce polynomial size in-place
         /// After binding n variables, evals() will return 2^(original_len - n) values
         pub fn bind(self: *Self, value: F) void {

--- a/src/utils/parallel_sort.zig
+++ b/src/utils/parallel_sort.zig
@@ -1,0 +1,244 @@
+//! Parallel sample sort using ThreadPool.
+//!
+//! For large arrays (>= 65536 elements), uses parallel sample sort:
+//! 1. Sample splitters from input
+//! 2. Classify elements into P buckets via binary search
+//! 3. Local pdq sort each bucket in parallel
+//!
+//! For small arrays, falls back to sequential std.sort.pdq.
+
+const std = @import("std");
+const ThreadPool = @import("thread_pool.zig").ThreadPool;
+
+/// Parallel sort using sample sort + pdq for large arrays.
+/// Falls back to sequential pdq for small arrays.
+pub fn parallelSort(
+    comptime T: type,
+    items: []T,
+    pool: *ThreadPool,
+    context: anytype,
+    comptime lessThanFn: fn (@TypeOf(context), T, T) bool,
+) void {
+    const Context = @TypeOf(context);
+    const MIN_PARALLEL_SIZE = 65536;
+
+    if (items.len < MIN_PARALLEL_SIZE) {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    }
+
+    // Determine number of buckets = number of threads + 1
+    const P = pool.thread_count + 1;
+    if (P <= 1) {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    }
+
+    // Step 1: Sample splitters
+    // Take every 64th element as a sample
+    const sample_stride = 64;
+    const n_samples = items.len / sample_stride;
+    if (n_samples < P) {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    }
+
+    const samples = pool.allocator.alloc(T, n_samples) catch {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    };
+    defer pool.allocator.free(samples);
+
+    for (0..n_samples) |i| {
+        samples[i] = items[i * sample_stride];
+    }
+    std.sort.pdq(T, samples, context, lessThanFn);
+
+    // Pick P-1 evenly spaced splitters
+    const n_splitters = P - 1;
+    const splitters = pool.allocator.alloc(T, n_splitters) catch {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    };
+    defer pool.allocator.free(splitters);
+
+    for (0..n_splitters) |i| {
+        const idx = (i + 1) * n_samples / P;
+        splitters[i] = samples[@min(idx, n_samples - 1)];
+    }
+
+    // Step 2: Count elements per bucket per thread chunk
+    const chunk_size = (items.len + P - 1) / P;
+    const n_chunks = (items.len + chunk_size - 1) / chunk_size;
+
+    // count_matrix[chunk][bucket]
+    const count_matrix = pool.allocator.alloc([]usize, n_chunks) catch {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    };
+    defer {
+        for (count_matrix[0..n_chunks]) |row| pool.allocator.free(row);
+        pool.allocator.free(count_matrix);
+    }
+    for (0..n_chunks) |c| {
+        count_matrix[c] = pool.allocator.alloc(usize, P) catch {
+            std.sort.pdq(T, items, context, lessThanFn);
+            return;
+        };
+        @memset(count_matrix[c], 0);
+    }
+
+    // Classify in parallel
+    const ClassifyCtx = struct {
+        items_ptr: []const T,
+        splitters_ptr: []const T,
+        count_mat: [][]usize,
+        chunk_sz: usize,
+        ctx: Context,
+
+        fn classify(self: @This(), chunk_idx: usize) void {
+            const start = chunk_idx * self.chunk_sz;
+            const end = @min(start + self.chunk_sz, self.items_ptr.len);
+            const counts = self.count_mat[chunk_idx];
+
+            for (start..end) |i| {
+                const bucket = binarySearchBucket(T, Context, self.splitters_ptr, self.items_ptr[i], self.ctx, lessThanFn);
+                counts[bucket] += 1;
+            }
+        }
+    };
+    const classify_ctx = ClassifyCtx{
+        .items_ptr = items,
+        .splitters_ptr = splitters,
+        .count_mat = count_matrix,
+        .chunk_sz = chunk_size,
+        .ctx = context,
+    };
+    pool.parallelForForce(n_chunks, classify_ctx, ClassifyCtx.classify);
+
+    // Step 3: Prefix sum to compute global offsets
+    // bucket_offsets[b] = start of bucket b in output
+    const bucket_offsets = pool.allocator.alloc(usize, P + 1) catch {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    };
+    defer pool.allocator.free(bucket_offsets);
+
+    bucket_offsets[0] = 0;
+    for (0..P) |b| {
+        var sum: usize = 0;
+        for (0..n_chunks) |c| {
+            sum += count_matrix[c][b];
+        }
+        bucket_offsets[b + 1] = bucket_offsets[b] + sum;
+    }
+
+    // Compute per-chunk write positions: write_pos[chunk][bucket] = start offset for this chunk's bucket
+    const write_pos = pool.allocator.alloc([]usize, n_chunks) catch {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    };
+    defer {
+        for (write_pos[0..n_chunks]) |row| pool.allocator.free(row);
+        pool.allocator.free(write_pos);
+    }
+    for (0..n_chunks) |c| {
+        write_pos[c] = pool.allocator.alloc(usize, P) catch {
+            std.sort.pdq(T, items, context, lessThanFn);
+            return;
+        };
+    }
+
+    for (0..P) |b| {
+        var pos = bucket_offsets[b];
+        for (0..n_chunks) |c| {
+            write_pos[c][b] = pos;
+            pos += count_matrix[c][b];
+        }
+    }
+
+    // Step 4: Scatter elements to output buffer in parallel
+    const output = pool.allocator.alloc(T, items.len) catch {
+        std.sort.pdq(T, items, context, lessThanFn);
+        return;
+    };
+    defer pool.allocator.free(output);
+
+    const ScatterCtx = struct {
+        items_ptr: []const T,
+        splitters_ptr: []const T,
+        out: []T,
+        w_pos: [][]usize,
+        chunk_sz: usize,
+        ctx: Context,
+
+        fn scatter(self: @This(), chunk_idx: usize) void {
+            const start = chunk_idx * self.chunk_sz;
+            const end = @min(start + self.chunk_sz, self.items_ptr.len);
+            const wp = self.w_pos[chunk_idx];
+
+            for (start..end) |i| {
+                const bucket = binarySearchBucket(T, Context, self.splitters_ptr, self.items_ptr[i], self.ctx, lessThanFn);
+                self.out[wp[bucket]] = self.items_ptr[i];
+                wp[bucket] += 1;
+            }
+        }
+    };
+    // Scatter is sequential per-chunk to avoid atomic writes (each chunk has unique write positions)
+    for (0..n_chunks) |c| {
+        const start = c * chunk_size;
+        const end = @min(start + chunk_size, items.len);
+        const wp = write_pos[c];
+        for (start..end) |i| {
+            const bucket = binarySearchBucket(T, Context, splitters, items[i], context, lessThanFn);
+            output[wp[bucket]] = items[i];
+            wp[bucket] += 1;
+        }
+    }
+
+    // Step 5: Sort each bucket in parallel with pdq
+    const SortCtx = struct {
+        out: []T,
+        b_offsets: []const usize,
+        ctx: Context,
+
+        fn sortBucket(self: @This(), bucket: usize) void {
+            const bstart = self.b_offsets[bucket];
+            const bend = self.b_offsets[bucket + 1];
+            if (bend > bstart) {
+                std.sort.pdq(T, self.out[bstart..bend], self.ctx, lessThanFn);
+            }
+        }
+    };
+    pool.parallelForForce(P, SortCtx{
+        .out = output,
+        .b_offsets = bucket_offsets,
+        .ctx = context,
+    }, SortCtx.sortBucket);
+
+    // Step 6: Copy sorted output back
+    @memcpy(items, output);
+}
+
+/// Binary search for the bucket index of an element given sorted splitters.
+/// Returns the index of the first splitter that is > element (or n_splitters if all <=).
+fn binarySearchBucket(
+    comptime T: type,
+    comptime Context: type,
+    splitters: []const T,
+    element: T,
+    context: Context,
+    comptime lessThanFn: fn (Context, T, T) bool,
+) usize {
+    var lo: usize = 0;
+    var hi: usize = splitters.len;
+    while (lo < hi) {
+        const mid = lo + (hi - lo) / 2;
+        if (lessThanFn(context, element, splitters[mid])) {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    return lo;
+}

--- a/src/zkvm/jolt_prover.zig
+++ b/src/zkvm/jolt_prover.zig
@@ -1272,10 +1272,29 @@ pub fn JoltProver(comptime F: type) type {
             @memcpy(padded_witnesses[0..cycle_witnesses.len], cycle_witnesses);
 
             // Fill padded cycles with NoOp witness values
-            for (cycle_witnesses.len..trace_length) |i| {
-                padded_witnesses[i] = r1cs.R1CSCycleInputs(F).init(); // All zeros
-                padded_witnesses[i].values[r1cs.R1CSInputIndex.FlagIsNoop.toIndex()] = F.one();
-                padded_witnesses[i].values[r1cs.R1CSInputIndex.FlagDoNotUpdateUnexpandedPC.toIndex()] = F.one();
+            {
+                const pad_len = trace_length - cycle_witnesses.len;
+                const pad_start = cycle_witnesses.len;
+                if (self.thread_pool != null and pad_len >= 256) {
+                    const PadCtx = struct {
+                        pw: []r1cs.R1CSCycleInputs(F),
+                        start: usize,
+                    };
+                    self.thread_pool.?.parallelFor(pad_len, PadCtx{ .pw = padded_witnesses, .start = pad_start }, struct {
+                        fn f(ctx: PadCtx, idx: usize) void {
+                            const i = ctx.start + idx;
+                            ctx.pw[i] = r1cs.R1CSCycleInputs(F).init();
+                            ctx.pw[i].values[r1cs.R1CSInputIndex.FlagIsNoop.toIndex()] = F.one();
+                            ctx.pw[i].values[r1cs.R1CSInputIndex.FlagDoNotUpdateUnexpandedPC.toIndex()] = F.one();
+                        }
+                    }.f);
+                } else {
+                    for (pad_start..trace_length) |i| {
+                        padded_witnesses[i] = r1cs.R1CSCycleInputs(F).init();
+                        padded_witnesses[i].values[r1cs.R1CSInputIndex.FlagIsNoop.toIndex()] = F.one();
+                        padded_witnesses[i].values[r1cs.R1CSInputIndex.FlagDoNotUpdateUnexpandedPC.toIndex()] = F.one();
+                    }
+                }
             }
 
 
@@ -2832,7 +2851,7 @@ pub fn JoltProver(comptime F: type) type {
                 for (0..s6_n_cycle_vars) |i| {
                     r_cycle_le[i] = s6_challenges[s6_bool_start + s6_log_k_chunk + i];
                 }
-                const eq_cycle = try stage6_mod.computeEqTable(F, self.allocator, r_cycle_le, s6_n_cycle_vars);
+                const eq_cycle = try stage6_mod.computeEqTableParallel(F, self.allocator, r_cycle_le, s6_n_cycle_vars, self.thread_pool);
                 defer self.allocator.free(eq_cycle);
 
                 // Compute G_i polynomials: G_i(k) = Σ_j eq(r_cycle, j) · (addr_chunk_i(j) == k ? 1 : 0)
@@ -2913,7 +2932,7 @@ pub fn JoltProver(comptime F: type) type {
                 for (0..s6_log_k_chunk) |i| {
                     r_addr_bool_le[i] = r_addr_bool_be[s6_log_k_chunk - 1 - i];
                 }
-                var eq_bool = try stage6_mod.computeEqTable(F, self.allocator, r_addr_bool_le, s6_log_k_chunk);
+                var eq_bool = try stage6_mod.computeEqTableParallel(F, self.allocator, r_addr_bool_le, s6_log_k_chunk, self.thread_pool);
                 defer self.allocator.free(eq_bool);
 
                 var eq_virt = try self.allocator.alloc([]F, N);
@@ -2927,7 +2946,7 @@ pub fn JoltProver(comptime F: type) type {
                     for (0..s6_log_k_chunk) |ci| {
                         r_virt_le[ci] = r_addr_virt[i][s6_log_k_chunk - 1 - ci];
                     }
-                    eq_virt[i] = try stage6_mod.computeEqTable(F, self.allocator, r_virt_le, s6_log_k_chunk);
+                    eq_virt[i] = try stage6_mod.computeEqTableParallel(F, self.allocator, r_virt_le, s6_log_k_chunk, self.thread_pool);
                     self.allocator.free(r_virt_le);
                 }
 

--- a/src/zkvm/ram/read_write_checking.zig
+++ b/src/zkvm/ram/read_write_checking.zig
@@ -344,7 +344,8 @@ pub fn RamReadWriteCheckingProver(comptime F: type) type {
             }
 
             // Sort entries by (cycle, address) for cycle-major ordering
-            std.mem.sort(Entry, entries.items, {}, struct {
+            // Use unstable sort (pdq) — no duplicate (cycle, address) pairs exist
+            std.mem.sortUnstable(Entry, entries.items, {}, struct {
                 fn lessThan(_: void, a: Entry, b: Entry) bool {
                     if (a.cycle != b.cycle) return a.cycle < b.cycle;
                     return a.address < b.address;
@@ -354,10 +355,10 @@ pub fn RamReadWriteCheckingProver(comptime F: type) type {
 
             // Initialize eq polynomial evaluations: eq(r_cycle, j) for each cycle j
             // r_cycle is in BIG_ENDIAN order (MSB first, as stored in tau)
-            const eq_evals = try allocator.alloc(F, T);
-            for (0..T) |j| {
-                eq_evals[j] = computeEqBigEndian(F, params.r_cycle, j, params.log_t);
-            }
+            // Use O(T) table construction instead of O(T·logT) per-element computation
+            const poly_mod = @import("../../poly/mod.zig");
+            const EqPoly = poly_mod.EqPolynomial(F);
+            const eq_evals = try EqPoly.evalsSliceWithScaling(F, allocator, params.r_cycle, null);
 
             const challenges_list = std.ArrayListUnmanaged(F){};
 
@@ -373,8 +374,8 @@ pub fn RamReadWriteCheckingProver(comptime F: type) type {
                 }
             }
 
-            // VERIFY: Check initial sum = Σ eq[j] * ra(k,j) * (val(k,j) + gamma*(val(k,j) + inc[j]))
-            {
+            // VERIFY: Check initial sum (debug only — O(N) + O(T) allocation)
+            if (comptime debug_verbose) {
                 var verify_init_sum = F.zero();
                 for (entries.items) |ve| {
                     const eq_j = if (ve.cycle < T) eq_evals[ve.cycle] else F.zero();
@@ -385,31 +386,25 @@ pub fn RamReadWriteCheckingProver(comptime F: type) type {
                 dbg("[RWC INIT VERIFY] initial_claim = {any}\n", .{initial_claim.toBytesBE()});
                 dbg("[RWC INIT VERIFY] sum_of_entries = {any}\n", .{verify_init_sum.toBytesBE()});
                 dbg("[RWC INIT VERIFY] match = {}\n", .{verify_init_sum.eql(initial_claim)});
-                // Also compute rv_claim and wv_claim separately
                 var rv_sum = F.zero();
                 var wv_sum = F.zero();
                 for (entries.items) |ve| {
                     const eq_j = if (ve.cycle < T) eq_evals[ve.cycle] else F.zero();
                     const inc_j = if (ve.cycle < T) inc[ve.cycle] else F.zero();
-                    // rv = Σ eq * ra * val
                     rv_sum = rv_sum.add(eq_j.mul(ve.ra_coeff).mul(ve.val_coeff));
-                    // wv = Σ eq * ra * (val + inc)
                     wv_sum = wv_sum.add(eq_j.mul(ve.ra_coeff).mul(ve.val_coeff.add(inc_j)));
                 }
                 dbg("[RWC INIT VERIFY] rv_sum = {any}\n", .{rv_sum.toBytesBE()});
                 dbg("[RWC INIT VERIFY] wv_sum = {any}\n", .{wv_sum.toBytesBE()});
                 dbg("[RWC INIT VERIFY] rv + gamma*wv = {any}\n", .{rv_sum.add(params.gamma.mul(wv_sum)).toBytesBE()});
-                // Also compute what initial_claim SHOULD be using a different eq convention
-                // Try LITTLE_ENDIAN eq
-                const poly_mod = @import("../../poly/mod.zig");
-                const EqPoly = poly_mod.EqPolynomial(F);
-                const eq_le_evals = try EqPoly.evalsSliceWithScaling(F, allocator, params.r_cycle, null);
+                const poly_mod_dbg = @import("../../poly/mod.zig");
+                const EqPolyDbg = poly_mod_dbg.EqPolynomial(F);
+                const eq_le_evals = try EqPolyDbg.evalsSliceWithScaling(F, allocator, params.r_cycle, null);
                 defer allocator.free(eq_le_evals);
                 const eq_le_54 = if (54 < eq_le_evals.len) eq_le_evals[54] else F.zero();
                 dbg("[RWC INIT VERIFY] eq_BE[54] = {any}\n", .{eq_evals[54].toBytesBE()});
                 dbg("[RWC INIT VERIFY] eq_LE[54] (EqPoly) = {any}\n", .{eq_le_54.toBytesBE()});
-                // Compute with LE eq
-                const sum_le = eq_le_54.mul(params.gamma); // rv=0, wv=eq*1, total=gamma*eq
+                const sum_le = eq_le_54.mul(params.gamma);
                 dbg("[RWC INIT VERIFY] gamma*eq_LE[54] = {any}\n", .{sum_le.toBytesBE()});
             }
 
@@ -607,7 +602,8 @@ pub fn RamReadWriteCheckingProver(comptime F: type) type {
             // Convert to AddressMajor at start of Phase 2
             if (addr_round == 0) {
                 // Sort entries by (address, cycle) for AddressMajor ordering
-                std.mem.sort(Entry, self.entries.items, {}, struct {
+                // Use unstable sort (pdq) — no duplicate (address, cycle) pairs exist
+                std.mem.sortUnstable(Entry, self.entries.items, {}, struct {
                     fn lessThan(_: void, a: Entry, b: Entry) bool {
                         if (a.address != b.address) return a.address < b.address;
                         return a.cycle < b.cycle;

--- a/src/zkvm/spartan/sparse_registers.zig
+++ b/src/zkvm/spartan/sparse_registers.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ThreadPool = @import("../../utils/thread_pool.zig").ThreadPool;
 const one_hot = @import("one_hot_coeffs.zig");
 const OneHotCoeffLookupTable = one_hot.OneHotCoeffLookupTable;
 const LookupTableIndex = one_hot.LookupTableIndex;
@@ -354,23 +355,38 @@ pub fn SparseRegistersCycleMajor(comptime F: type, comptime use_lookups: bool) t
 
         // ---- Construction from trace (only for use_lookups=true) ----
 
-        pub fn fromTrace(allocator: Allocator, trace: *const ExecutionTrace, gamma: F) !Self {
+        pub fn fromTrace(allocator: Allocator, trace: *const ExecutionTrace, gamma: F, pool: ?*ThreadPool) !Self {
             if (!use_lookups) @compileError("fromTrace only for use_lookups=true");
 
             const trace_len = trace.steps.items.len;
             const T = std.math.ceilPowerOfTwo(usize, trace_len) catch trace_len;
 
-            // Pass 1: count entries per cycle
+            // Pass 1: count entries per cycle (parallelizable — each step independent)
             const counts = try allocator.alloc(u8, T);
             defer allocator.free(counts);
             @memset(counts, 0);
 
-            for (trace.steps.items, 0..) |step, j| {
-                if (step.is_noop) continue;
-                counts[j] = entryCountForStep(step);
+            if (pool != null and trace_len >= 256) {
+                const CountCtx = struct {
+                    steps: []const TraceStep,
+                    cnts: []u8,
+                };
+                pool.?.parallelFor(trace_len, CountCtx{ .steps = trace.steps.items, .cnts = counts }, struct {
+                    fn f(ctx: CountCtx, j: usize) void {
+                        const step = ctx.steps[j];
+                        if (!step.is_noop) {
+                            ctx.cnts[j] = entryCountForStep(step);
+                        }
+                    }
+                }.f);
+            } else {
+                for (trace.steps.items, 0..) |step, j| {
+                    if (step.is_noop) continue;
+                    counts[j] = entryCountForStep(step);
+                }
             }
 
-            // Prefix sum for offsets
+            // Prefix sum for offsets (sequential — O(T) additions on u8, negligible)
             var total: usize = 0;
             const offsets = try allocator.alloc(usize, T + 1);
             defer allocator.free(offsets);
@@ -380,30 +396,47 @@ pub fn SparseRegistersCycleMajor(comptime F: type, comptime use_lookups: bool) t
                 offsets[j + 1] = total;
             }
 
-            // Pass 2: fill entries
+            // Pass 2: fill entries (parallelizable — each cycle writes to disjoint slices)
+            // Uses TraceStep pre-recorded values (rs1_value, rs2_value, rd_pre_value)
+            // instead of tracking register_values across cycles.
             const entries = try allocator.alloc(Entry, total);
 
-            // Track register values across cycles
-            var register_values: [K]u64 = [_]u64{0} ** K;
-
-            for (0..T) |j| {
-                if (j >= trace_len) continue;
-                const step = trace.steps.items[j];
-
-                const out = entries[offsets[j]..offsets[j + 1]];
-                if (!step.is_noop and out.len > 0) {
-                    fillEntriesForStep(@intCast(j), step, &register_values, out);
-                }
-
-                // Update register values (must happen after filling, for prev_val)
-                if (!step.is_noop and step.rd_written) {
-                    register_values[step.rd_index] = step.rd_value;
+            if (pool != null and trace_len >= 256) {
+                const FillCtx = struct {
+                    steps: []const TraceStep,
+                    ents: []Entry,
+                    offs: []const usize,
+                    tlen: usize,
+                };
+                pool.?.parallelFor(T, FillCtx{
+                    .steps = trace.steps.items,
+                    .ents = entries,
+                    .offs = offsets,
+                    .tlen = trace_len,
+                }, struct {
+                    fn f(ctx: FillCtx, j: usize) void {
+                        if (j >= ctx.tlen) return;
+                        const step = ctx.steps[j];
+                        const out = ctx.ents[ctx.offs[j]..ctx.offs[j + 1]];
+                        if (!step.is_noop and out.len > 0) {
+                            fillEntriesForStepIndependent(@intCast(j), step, out);
+                        }
+                    }
+                }.f);
+            } else {
+                for (0..T) |j| {
+                    if (j >= trace_len) continue;
+                    const step = trace.steps.items[j];
+                    const out = entries[offsets[j]..offsets[j + 1]];
+                    if (!step.is_noop and out.len > 0) {
+                        fillEntriesForStepIndependent(@intCast(j), step, out);
+                    }
                 }
             }
 
-            // Sort entries by (row, col) - should already be sorted since we fill in order
-            // but entries within a cycle might not be sorted by col
-            std.sort.block(Entry, entries, {}, struct {
+            // Sort entries by (row, col) - nearly sorted (filled in cycle order),
+            // pdq detects this and runs near-O(N)
+            std.sort.pdq(Entry, entries, {}, struct {
                 fn cmp(_: void, a: Entry, b: Entry) bool {
                     if (a.row != b.row) return a.row < b.row;
                     return a.col < b.col;
@@ -529,6 +562,90 @@ pub fn SparseRegistersCycleMajor(comptime F: type, comptime use_lookups: bool) t
                 }
                 if (!merged_rd) {
                     const pre_val = reg_vals[rd];
+                    out[len] = .{
+                        .row = row,
+                        .col = rd,
+                        .prev_val = pre_val,
+                        .next_val = step.rd_value,
+                        .val_coeff = F.fromU64(pre_val),
+                        .ra_coeff = if (use_lookups) LookupTableIndex.zero() else F.zero(),
+                        .wa_coeff = if (use_lookups) LookupTableIndex.fromU16(1) else F.one(),
+                    };
+                    len += 1;
+                }
+            }
+
+            std.debug.assert(len == out.len);
+
+            // Sort by col (len <= 3, manual bubble sort)
+            if (len == 2 and out[0].col > out[1].col) {
+                std.mem.swap(Entry, &out[0], &out[1]);
+            } else if (len == 3) {
+                if (out[0].col > out[1].col) std.mem.swap(Entry, &out[0], &out[1]);
+                if (out[1].col > out[2].col) std.mem.swap(Entry, &out[1], &out[2]);
+                if (out[0].col > out[1].col) std.mem.swap(Entry, &out[0], &out[1]);
+            }
+        }
+
+        /// Fill entries for a single step using TraceStep pre-recorded values.
+        /// No external register_values array needed — reads rs1_value, rs2_value,
+        /// rd_pre_value directly from the step. Safe for parallel use.
+        fn fillEntriesForStepIndependent(row: u32, step: TraceStep, out: []Entry) void {
+            var len: usize = 0;
+
+            if (step.rs1_read) {
+                const rs1 = step.rs1_index;
+                const val = step.rs1_value;
+                out[len] = .{
+                    .row = row,
+                    .col = rs1,
+                    .prev_val = val,
+                    .next_val = val,
+                    .val_coeff = F.fromU64(val),
+                    .ra_coeff = LookupTableIndex.fromU16(1), // gamma
+                    .wa_coeff = LookupTableIndex.zero(),
+                };
+                len += 1;
+            }
+
+            if (step.rs2_read) {
+                var merged = false;
+                for (out[0..len]) |*e| {
+                    if (e.col == step.rs2_index) {
+                        e.ra_coeff = LookupTableIndex.fromU16(3); // gamma + gamma^2
+                        merged = true;
+                        break;
+                    }
+                }
+                if (!merged) {
+                    const rs2 = step.rs2_index;
+                    const val = step.rs2_value;
+                    out[len] = .{
+                        .row = row,
+                        .col = rs2,
+                        .prev_val = val,
+                        .next_val = val,
+                        .val_coeff = F.fromU64(val),
+                        .ra_coeff = LookupTableIndex.fromU16(2), // gamma^2
+                        .wa_coeff = LookupTableIndex.zero(),
+                    };
+                    len += 1;
+                }
+            }
+
+            if (step.rd_written) {
+                const rd = step.rd_index;
+                var merged_rd = false;
+                for (out[0..len]) |*e| {
+                    if (e.col == rd) {
+                        e.wa_coeff = LookupTableIndex.fromU16(1);
+                        e.next_val = step.rd_value;
+                        merged_rd = true;
+                        break;
+                    }
+                }
+                if (!merged_rd) {
+                    const pre_val = step.rd_pre_value;
                     out[len] = .{
                         .row = row,
                         .col = rd,
@@ -837,7 +954,8 @@ pub fn SparseRegistersCycleMajor(comptime F: type, comptime use_lookups: bool) t
             }
 
             // Sort by (col, row) for address-major order
-            std.sort.block(AMEntry, am_entries, {}, struct {
+            // pdq has smaller constants than block sort and no auxiliary allocation
+            std.sort.pdq(AMEntry, am_entries, {}, struct {
                 fn cmp(_: void, a: AMEntry, b: AMEntry) bool {
                     if (a.col != b.col) return a.col < b.col;
                     return a.row < b.row;

--- a/src/zkvm/spartan/stage4_gruen_prover.zig
+++ b/src/zkvm/spartan/stage4_gruen_prover.zig
@@ -160,23 +160,17 @@ pub fn Stage4GruenProver(comptime F: type) type {
             const gamma_sq = gamma.mul(gamma);
 
             // Build sparse matrix from trace
-            var sparse_lookup = try SparseRegsLookup.fromTrace(allocator, trace, gamma);
+            var sparse_lookup = try SparseRegsLookup.fromTrace(allocator, trace, gamma, null);
             errdefer sparse_lookup.deinit();
 
             // Build dense inc_poly from trace
+            // Uses TraceStep pre-recorded rd_pre_value — no sequential register tracking needed
             const inc_poly = try allocator.alloc(F, T);
             @memset(inc_poly, F.zero());
-            {
-                var register_values: [K]u64 = [_]u64{0} ** K;
-                for (trace.steps.items, 0..) |step, cycle| {
-                    if (step.is_noop) continue;
-                    if (step.rd_written and step.rd_index != 0) {
-                        const rd = step.rd_index;
-                        const pre_value = register_values[rd];
-                        const post_value = step.rd_value;
-                        inc_poly[cycle] = F.fromU64(post_value).sub(F.fromU64(pre_value));
-                        register_values[rd] = post_value;
-                    }
+            for (trace.steps.items, 0..) |step, cycle| {
+                if (step.is_noop) continue;
+                if (step.rd_written and step.rd_index != 0) {
+                    inc_poly[cycle] = F.fromU64(step.rd_value).sub(F.fromU64(step.rd_pre_value));
                 }
             }
 

--- a/src/zkvm/spartan/stage6_prover.zig
+++ b/src/zkvm/spartan/stage6_prover.zig
@@ -1439,6 +1439,7 @@ fn IncClaimReductionProver(comptime F: type) type {
             r_cycle_stage4: []const F,
             s_cycle_stage4: []const F,
             s_cycle_stage5: []const F,
+            pool: ?*ThreadPool,
         ) !Self {
             const T = trace.steps.items.len;
             const n_vars = std.math.log2_int(usize, T);
@@ -1446,25 +1447,14 @@ fn IncClaimReductionProver(comptime F: type) type {
             var ram_inc_arr = try allocator.alloc(F, T);
             var rd_inc_arr = try allocator.alloc(F, T);
 
-            // Track register values across cycles - MUST match Stage 4 gruen prover:
-            // - Use step.rd_index (supports virtual registers 0-127)
-            // - Use step.rd_written flag (not opcode-based detection)
-            // - Track all 128 registers (K=128)
-            const K_INC = 128; // Must match Stage 4's K
-            var register_values: [K_INC]u64 = [_]u64{0} ** K_INC;
-
+            // Uses TraceStep pre-recorded rd_pre_value — no sequential register tracking needed.
+            // Must match Stage 4 gruen prover's inc_poly computation exactly.
             for (0..T) |j| {
                 const step = trace.steps.items[j];
 
-                // RdInc: must match Stage 4 gruen prover's inc_poly computation exactly.
-                // Skip rd=0: in upstream Jolt, x0 is hardwired to 0 so inc is always 0.
-                // Stage 4 also skips rd=0 in inc_poly.
+                // RdInc: skip rd=0 (x0 hardwired to 0, inc always 0)
                 if (!step.is_noop and step.rd_written and step.rd_index != 0) {
-                    const rd = step.rd_index;
-                    const pre_value = register_values[rd];
-                    const post_value = step.rd_value;
-                    rd_inc_arr[j] = F.fromU64(post_value).sub(F.fromU64(pre_value));
-                    register_values[rd] = post_value;
+                    rd_inc_arr[j] = F.fromU64(step.rd_value).sub(F.fromU64(step.rd_pre_value));
                 } else {
                     rd_inc_arr[j] = F.zero();
                 }
@@ -1484,19 +1474,19 @@ fn IncClaimReductionProver(comptime F: type) type {
             defer allocator.free(rev_buf);
 
             for (0..n_vars) |i| rev_buf[i] = r_cycle_stage2[n_vars - 1 - i];
-            const eq_stage2 = try computeEqTable(F, allocator, rev_buf, n_vars);
+            const eq_stage2 = try computeEqTableParallel(F, allocator, rev_buf, n_vars, pool);
             defer allocator.free(eq_stage2);
 
             for (0..n_vars) |i| rev_buf[i] = r_cycle_stage4[n_vars - 1 - i];
-            const eq_stage4 = try computeEqTable(F, allocator, rev_buf, n_vars);
+            const eq_stage4 = try computeEqTableParallel(F, allocator, rev_buf, n_vars, pool);
             defer allocator.free(eq_stage4);
 
             for (0..n_vars) |i| rev_buf[i] = s_cycle_stage4[n_vars - 1 - i];
-            const eq_s4 = try computeEqTable(F, allocator, rev_buf, n_vars);
+            const eq_s4 = try computeEqTableParallel(F, allocator, rev_buf, n_vars, pool);
             defer allocator.free(eq_s4);
 
             for (0..n_vars) |i| rev_buf[i] = s_cycle_stage5[n_vars - 1 - i];
-            const eq_s5 = try computeEqTable(F, allocator, rev_buf, n_vars);
+            const eq_s5 = try computeEqTableParallel(F, allocator, rev_buf, n_vars, pool);
             defer allocator.free(eq_s5);
 
             var eq_ram_arr = try allocator.alloc(F, T);
@@ -1515,6 +1505,7 @@ fn IncClaimReductionProver(comptime F: type) type {
                 .gamma_sqr = gamma.mul(gamma),
                 .current_len = T,
                 .allocator = allocator,
+                .pool = pool,
             };
         }
 
@@ -1647,6 +1638,7 @@ fn HammingBooleanityProver(comptime F: type) type {
             allocator: Allocator,
             trace: *const ExecutionTrace,
             r_cycle: []const F,
+            pool: ?*ThreadPool,
         ) !Self {
             const T = trace.steps.items.len;
             const n_vars = std.math.log2_int(usize, T);
@@ -1665,13 +1657,14 @@ fn HammingBooleanityProver(comptime F: type) type {
             var r_cycle_rev = try allocator.alloc(F, n_vars);
             defer allocator.free(r_cycle_rev);
             for (0..n_vars) |i| r_cycle_rev[i] = r_cycle[n_vars - 1 - i];
-            const eq_arr = try computeEqTable(F, allocator, r_cycle_rev, n_vars);
+            const eq_arr = try computeEqTableParallel(F, allocator, r_cycle_rev, n_vars, pool);
 
             return Self{
                 .H = H_arr,
                 .eq = eq_arr,
                 .current_len = T,
                 .allocator = allocator,
+                .pool = pool,
             };
         }
 
@@ -1796,6 +1789,7 @@ fn RamRaVirtualProver(comptime F: type) type {
             d: usize,
             memory_layout: *const jolt_device.MemoryLayout,
             log_k_chunk: usize,
+            init_pool: ?*ThreadPool,
         ) !Self {
             const T = trace.steps.items.len;
             const n_vars = std.math.log2_int(usize, T);
@@ -1811,6 +1805,7 @@ fn RamRaVirtualProver(comptime F: type) type {
                 ra_bound_arr[i] = try allocator.alloc(F, T);
 
                 // r_addr_chunks[i] is in BE order; reverse for LE computeEqTable
+                // Small table (chunk-sized), no parallelism needed
                 var r_chunk_rev = try allocator.alloc(F, log_k_chunk);
                 defer allocator.free(r_chunk_rev);
                 for (0..log_k_chunk) |ci| r_chunk_rev[ci] = r_addr_chunks[i][log_k_chunk - 1 - ci];
@@ -1848,7 +1843,7 @@ fn RamRaVirtualProver(comptime F: type) type {
             var r_cycle_rev = try allocator.alloc(F, n_vars);
             defer allocator.free(r_cycle_rev);
             for (0..n_vars) |i| r_cycle_rev[i] = r_cycle[n_vars - 1 - i];
-            const eq_arr = try computeEqTable(F, allocator, r_cycle_rev, n_vars);
+            const eq_arr = try computeEqTableParallel(F, allocator, r_cycle_rev, n_vars, init_pool);
 
             return Self{
                 .ra_bound = ra_bound_arr,
@@ -1856,6 +1851,7 @@ fn RamRaVirtualProver(comptime F: type) type {
                 .d = d,
                 .current_len = T,
                 .allocator = allocator,
+                .pool = init_pool,
             };
         }
 
@@ -2757,6 +2753,7 @@ fn LookupsRaVirtualProver(comptime F: type) type {
             N: usize,
             log_k_chunk: usize,
             instruction_d: usize,
+            init_pool: ?*ThreadPool,
         ) !Self {
             const T = trace.steps.items.len;
             const n_vars = std.math.log2_int(usize, T);
@@ -2851,7 +2848,7 @@ fn LookupsRaVirtualProver(comptime F: type) type {
             var r_cycle_rev = try allocator.alloc(F, n_vars);
             defer allocator.free(r_cycle_rev);
             for (0..n_vars) |i| r_cycle_rev[i] = r_cycle[n_vars - 1 - i];
-            const eq_arr = try computeEqTable(F, allocator, r_cycle_rev, n_vars);
+            const eq_arr = try computeEqTableParallel(F, allocator, r_cycle_rev, n_vars, init_pool);
 
             // Verify: sum over all cycles should equal the input claim
             {
@@ -2936,6 +2933,7 @@ fn LookupsRaVirtualProver(comptime F: type) type {
                 .total_committed = total_committed,
                 .current_len = T,
                 .allocator = allocator,
+                .pool = init_pool,
             };
         }
 
@@ -3152,6 +3150,7 @@ fn BytecodeReadRafProver(comptime F: type) type {
             stage_r_cycles: [5][]const F,
             int_poly: []F,
             external_stage_claims: [5]F, // From opening claims: claim_per_stage[s]
+            init_pool: ?*ThreadPool,
         ) !Self {
             const bytecode_K: usize = @as(usize, 1) << @intCast(bytecode_log_k);
             const T: usize = @as(usize, 1) << @intCast(n_cycle_vars);
@@ -3171,7 +3170,7 @@ fn BytecodeReadRafProver(comptime F: type) type {
                 for (0..n_cycle_vars) |i| {
                     r_cycle_rev[i] = stage_r_cycles[s][n_cycle_vars - 1 - i];
                 }
-                const eq_table = try computeEqTable(F, allocator, r_cycle_rev, n_cycle_vars);
+                const eq_table = try computeEqTableParallel(F, allocator, r_cycle_rev, n_cycle_vars, init_pool);
                 defer allocator.free(eq_table);
 
                 // F_s[k] = Sum_{c: PC(c)=k} eq(r_cycle_s, c)
@@ -3524,6 +3523,7 @@ fn BytecodeReadRafProver(comptime F: type) type {
                 .val_polys = val_polys,
                 .int_poly = int_poly,
                 .allocator = allocator,
+                .pool = init_pool,
             };
         }
 
@@ -3746,7 +3746,7 @@ fn BytecodeReadRafProver(comptime F: type) type {
             // Jolt's verifier reverses challenges (normalize_opening_point) before evaluate,
             // so r[0] = LSB challenge maps to bit 0 of coefficient index.
             // We must do the same: use r_address_be (reversed) for the eq table.
-            const eq_addr = try computeEqTable(F, self.allocator, r_address_be, self.bytecode_log_k);
+            const eq_addr = try computeEqTableParallel(F, self.allocator, r_address_be, self.bytecode_log_k, self.pool);
             defer self.allocator.free(eq_addr);
 
             // Debug: eq_addr entries (ALWAYS ON, full 32 bytes)
@@ -3943,7 +3943,7 @@ fn BytecodeReadRafProver(comptime F: type) type {
                 for (0..self.n_cycle_vars) |i| {
                     r_cycle_rev[i] = self.stage_r_cycles[s][self.n_cycle_vars - 1 - i];
                 }
-                eq_per_stage[s] = try computeEqTable(F, self.allocator, r_cycle_rev, self.n_cycle_vars);
+                eq_per_stage[s] = try computeEqTableParallel(F, self.allocator, r_cycle_rev, self.n_cycle_vars, self.pool);
             }
 
             // Compute combined[c] = Sum_s bound_vals[s] * eq_s(c)
@@ -4585,8 +4585,8 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 self.allocator, trace, inc_gamma,
                 r_cycle_inc_ram_rwc, r_cycle_inc_ram_val,
                 r_cycle_bc4_regs_rwc, r_cycle_bc5_regs_val,
+                self.thread_pool,
             );
-            inc_prover.pool = self.thread_pool;
             defer inc_prover.deinit();
 
             // Direct comparison: Stage 6 rd_inc vs Stage 4 inc_poly
@@ -4688,16 +4688,16 @@ pub fn Stage6BatchedProver(comptime F: type) type {
             // Instance 1: HammingBooleanity (degree 3)
             var hamming_prover = try HammingBooleanityProver(F).init(
                 self.allocator, trace, r_cycle_bc1_spartan_outer,
+                self.thread_pool,
             );
-            hamming_prover.pool = self.thread_pool;
             defer hamming_prover.deinit();
 
             // Instance 3: RamRaVirtual (degree ram_d+1)
             var ram_ra_prover = try RamRaVirtualProver(F).init(
                 self.allocator, trace, ram_ra_r_cycle,
                 ram_ra_addr_chunks, ram_d, memory_layout, log_k_chunk,
+                self.thread_pool,
             );
-            ram_ra_prover.pool = self.thread_pool;
             defer ram_ra_prover.deinit();
 
             // Instance 4: LookupsRaVirtual (degree n_committed_per_virtual+1)
@@ -4706,8 +4706,8 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 lookups_ra_addr_chunks, lookups_ra_gamma_powers,
                 n_committed_per_virtual, n_virtual_ra_polys,
                 log_k_chunk, instruction_d,
+                self.thread_pool,
             );
-            lookups_ra_prover.pool = self.thread_pool;
             defer lookups_ra_prover.deinit();
 
             // Instance 2: Booleanity (degree 3, two-phase)
@@ -4770,7 +4770,7 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 // After Phase 2 halving with LowToHigh binding, the final eq value equals
                 // eq(challenges, r_cycle_BE) = eq(challenges, rev(r_cycle_LE)), matching
                 // Jolt's verifier which computes combined_r_cycle = rev(r_cycle_LE).
-                const eq_cycle_bool_phase2 = try computeEqTable(F, self.allocator, lookups_ra_r_cycle, n_cycle_vars);
+                const eq_cycle_bool_phase2 = try computeEqTableParallel(F, self.allocator, lookups_ra_r_cycle, n_cycle_vars, self.thread_pool);
                 // eq_cycle_bool_phase2 is NOT deferred - shared with BooleanityProver
 
                 // Build G tables: G_i[k] = Σ_j eq(r_cycle_fixed, j) * [chunk_i(j) == k]
@@ -5139,7 +5139,7 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 var r_cycle_rev = try self.allocator.alloc(F, n_vars);
                 defer self.allocator.free(r_cycle_rev);
                 for (0..n_vars) |i| r_cycle_rev[i] = r_cycle_bc1_spartan_outer[n_vars - 1 - i];
-                const eq_table_s1 = try computeEqTable(F, self.allocator, r_cycle_rev, n_vars);
+                const eq_table_s1 = try computeEqTableParallel(F, self.allocator, r_cycle_rev, n_vars, self.thread_pool);
                 defer self.allocator.free(eq_table_s1);
 
                 // Compute F_s[k] = Σ_{c:PC(c)=k} eq(r_cycle, c) for Stage 1
@@ -5267,7 +5267,7 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 var r_cycle_rev2 = try self.allocator.alloc(F, n_vars);
                 defer self.allocator.free(r_cycle_rev2);
                 for (0..n_vars) |i| r_cycle_rev2[i] = r_cycle_bc2_product_virt[n_vars - 1 - i];
-                const eq_table_s2 = try computeEqTable(F, self.allocator, r_cycle_rev2, n_vars);
+                const eq_table_s2 = try computeEqTableParallel(F, self.allocator, r_cycle_rev2, n_vars, self.thread_pool);
                 defer self.allocator.free(eq_table_s2);
 
                 // Compute per-field sums: Σ_c eq(r_cycle_2, c) * witness_field[c]
@@ -5353,7 +5353,7 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 var r_cycle_rev4 = try self.allocator.alloc(F, n_vars);
                 defer self.allocator.free(r_cycle_rev4);
                 for (0..n_vars) |i| r_cycle_rev4[i] = r_cycle_bc4_regs_rwc[n_vars - 1 - i];
-                const eq_table_s4 = try computeEqTable(F, self.allocator, r_cycle_rev4, n_vars);
+                const eq_table_s4 = try computeEqTableParallel(F, self.allocator, r_cycle_rev4, n_vars, self.thread_pool);
                 defer self.allocator.free(eq_table_s4);
 
                 // For each field (rd, rs1, rs2), compute Σ_k F_s[k] * eq(entry[k].reg, r_register_4)
@@ -5643,7 +5643,7 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 var r_cycle_rev5 = try self.allocator.alloc(F, n_vars);
                 defer self.allocator.free(r_cycle_rev5);
                 for (0..n_vars) |i| r_cycle_rev5[i] = r_cycle_bc5_regs_val[n_vars - 1 - i];
-                const eq_table_s5 = try computeEqTable(F, self.allocator, r_cycle_rev5, n_vars);
+                const eq_table_s5 = try computeEqTableParallel(F, self.allocator, r_cycle_rev5, n_vars, self.thread_pool);
                 defer self.allocator.free(eq_table_s5);
 
                 var F_s5 = try self.allocator.alloc(F, bytecode_K);
@@ -5812,8 +5812,8 @@ pub fn Stage6BatchedProver(comptime F: type) type {
                 },
                 bytecode_int_poly,
                 bcraf_per_stage_claims,
+                self.thread_pool,
             );
-            bytecode_prover.pool = self.thread_pool;
             defer bytecode_prover.deinit();
 
             // Debug: Compare prover's initial BytecodeReadRaf claim with opening-claims-derived claim
@@ -7603,6 +7603,12 @@ fn addFixedEvalsToCombibed(comptime F: type, combined_evals: []F, polys: []const
 /// Compute eq polynomial table: eq(r, j) for all j in [0, 2^n_vars)
 /// r is in BIG_ENDIAN order (r[0] is the most significant variable)
 pub fn computeEqTable(comptime F: type, allocator: Allocator, r: []const F, n_vars: usize) ![]F {
+    return computeEqTableParallel(F, allocator, r, n_vars, null);
+}
+
+/// Compute eq polynomial table with optional parallel inner loops.
+/// Same as computeEqTable but parallelizes large levels via ThreadPool.
+pub fn computeEqTableParallel(comptime F: type, allocator: Allocator, r: []const F, n_vars: usize, pool: ?*ThreadPool) ![]F {
     const size: usize = @as(usize, 1) << @intCast(n_vars);
     var table = try allocator.alloc(F, size);
 
@@ -7610,14 +7616,34 @@ pub fn computeEqTable(comptime F: type, allocator: Allocator, r: []const F, n_va
 
     for (0..n_vars) |i| {
         const r_i = r[i];
-        const one_minus_r = F.one().sub(r_i);
         const cur_size: usize = @as(usize, 1) << @intCast(i);
 
-        var j: usize = cur_size;
-        while (j > 0) {
-            j -= 1;
-            table[j + cur_size] = table[j].mul(r_i);
-            table[j] = table[j].mul(one_minus_r);
+        if (pool != null and cur_size >= 256) {
+            // Parallel: forward iteration, writes to disjoint halves [0..cur_size) and [cur_size..2*cur_size)
+            const Ctx = struct {
+                tbl: []F,
+                ri: F,
+                cs: usize,
+            };
+            const ctx = Ctx{ .tbl = table, .ri = r_i, .cs = cur_size };
+            pool.?.parallelForForce(cur_size, ctx, struct {
+                fn f(c: Ctx, j: usize) void {
+                    const x = c.tbl[j];
+                    const y = x.mul(c.ri);
+                    c.tbl[j + c.cs] = y;
+                    c.tbl[j] = x.sub(y);
+                }
+            }.f);
+        } else {
+            // Sequential: backward iteration (original)
+            var j: usize = cur_size;
+            while (j > 0) {
+                j -= 1;
+                const x = table[j];
+                const y = x.mul(r_i);
+                table[j + cur_size] = y;
+                table[j] = x.sub(y);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #46

- **Gate debug block** in RAM init behind `comptime debug_verbose` — eliminates dead O(N) loops + allocation
- **Replace O(T·logT) eq loop** with O(T) `evalsSliceWithScaling` table construction in RAM read-write checking init
- **Add `computeEqTableParallel` / `evalsSliceWithScalingParallel`** — parallelizes inner loop via ThreadPool when level size >= 256; update ~20 call sites across stage6 sub-provers (IncClaim, Hamming, RamRa, LookupsRa, BytecodeReadRaf, Booleanity) and Stage 7
- **Parallelize sparse register `fromTrace`** — uses `step.rs1_value/rs2_value/rd_pre_value` directly instead of sequential `register_values[]` tracking; both count and fill passes dispatch via ThreadPool
- **Switch sorts to pdq** — `std.mem.sortUnstable` (RAM entries) and `std.sort.pdq` (sparse registers); add `parallel_sort.zig` sample sort for future 2^30 scale
- **Parallelize witness NoOp padding** via ThreadPool

## Test plan

- [x] All 8 programs verified against upstream Jolt verifier (fibonacci, factorial, bitwise, collatz, primes, sum, gcd, signed)
- [x] primes_large (2^16) verified — 8.2s → 8.0s (modest at this scale, compounds at 2^30)
- [x] Clean build with `-Doptimize=ReleaseFast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)