### PR TITLE
feat: add Web Workers for parallel WASM proving

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,10 @@ pub fn build(b: *std.Build) void {
     const is_wasm = target.result.cpu.arch == .wasm32 or
         target.result.cpu.arch == .wasm64;
 
+    // Detect WASM atomics — enables multi-threaded mode for Web Workers
+    const has_wasm_atomics = is_wasm and
+        std.Target.wasm.featureSetHas(target.result.cpu.features, .atomics);
+
     // Package dependencies
     const zolt_pool_dep = b.dependency("zolt_pool", .{
         .target = target,
@@ -31,37 +35,6 @@ pub fn build(b: *std.Build) void {
     });
     const zolt_arith_mod = zolt_arith_dep.module("zolt_arith");
 
-    // Main library
-    const lib = b.addLibrary(.{
-        .name = "zolt",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/root.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "zolt_pool", .module = zolt_pool_mod },
-                .{ .name = "zolt_arith", .module = zolt_arith_mod },
-            },
-        }),
-    });
-    if (is_apple_silicon) linkMetalFrameworks(lib.root_module);
-    b.installArtifact(lib);
-
-    // C-API static library (for FFI from Rust/C/WASM)
-    const capi_lib = b.addLibrary(.{
-        .name = "zolt_capi",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/c_api.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "zolt_pool", .module = zolt_pool_mod },
-                .{ .name = "zolt_arith", .module = zolt_arith_mod },
-            },
-        }),
-    });
-    if (is_apple_silicon) linkMetalFrameworks(capi_lib.root_module);
-    b.installArtifact(capi_lib);
 
     // Export zolt module for dependency consumption
     _ = b.addModule("zolt", .{
@@ -74,9 +47,115 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    // ── Native-only targets (executables, tests, benchmarks) ─────────
+    // ── WASM executable target (browser-loadable .wasm module) ─────────
+    if (is_wasm) {
+        const wasm_mod = b.addExecutable(.{
+            .name = "zolt_capi",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/c_api.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "zolt_pool", .module = zolt_pool_mod },
+                    .{ .name = "zolt_arith", .module = zolt_arith_mod },
+                },
+            }),
+        });
+        wasm_mod.entry = .disabled;
+        wasm_mod.initial_memory = 256 * 1024 * 1024; // 256 MB
+        wasm_mod.max_memory = if (target.result.cpu.arch == .wasm64)
+            16 * 1024 * 1024 * 1024 // 16 GB (wasm64, wasm-ld max)
+        else
+            4 * 1024 * 1024 * 1024; // 4 GB (wasm32 max)
+        wasm_mod.root_module.export_symbol_names = if (has_wasm_atomics)
+            &.{
+                "zolt_alloc",
+                "zolt_free",
+                "zolt_thread_pool_create",
+                "zolt_thread_pool_destroy",
+                "zolt_load_elf",
+                "zolt_load_elf_bytes",
+                "zolt_loaded_elf_size",
+                "zolt_loaded_elf_destroy",
+                "zolt_prove",
+                "zolt_proof_result_size",
+                "zolt_proof_result_ptr",
+                "zolt_proof_result_destroy",
+                "zolt_thread_pool_create_wasm",
+                "zolt_thread_pool_ptr",
+                "zolt_worker_entry",
+                // Workers need their own stack and TLS regions
+                "__stack_pointer",
+                "__tls_base",
+                "__tls_size",
+                "__tls_align",
+                "__wasm_init_tls",
+            }
+        else
+            &.{
+                "zolt_alloc",
+                "zolt_free",
+                "zolt_thread_pool_create",
+                "zolt_thread_pool_destroy",
+                "zolt_load_elf",
+                "zolt_load_elf_bytes",
+                "zolt_loaded_elf_size",
+                "zolt_loaded_elf_destroy",
+                "zolt_prove",
+                "zolt_proof_result_size",
+                "zolt_proof_result_ptr",
+                "zolt_proof_result_destroy",
+                "zolt_thread_pool_create_wasm",
+                "zolt_thread_pool_ptr",
+                "zolt_worker_entry",
+            };
+
+        if (has_wasm_atomics) {
+            // Enable shared memory for Web Workers + SharedArrayBuffer
+            wasm_mod.shared_memory = true;
+            wasm_mod.import_memory = true; // JS creates SharedArrayBuffer
+            wasm_mod.export_memory = true; // re-export so JS can access via instance.exports.memory
+        } else {
+            wasm_mod.export_memory = true;
+        }
+        b.installArtifact(wasm_mod);
+    }
+
+    // ── Native-only targets (libraries, executables, tests, benchmarks) ──
     // These require OS threads, filesystem, and can't run on WASM.
     if (!is_wasm) {
+        // Main library
+        const lib = b.addLibrary(.{
+            .name = "zolt",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/root.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "zolt_pool", .module = zolt_pool_mod },
+                    .{ .name = "zolt_arith", .module = zolt_arith_mod },
+                },
+            }),
+        });
+        if (is_apple_silicon) linkMetalFrameworks(lib.root_module);
+        b.installArtifact(lib);
+
+        // C-API static library (for FFI from Rust/C)
+        const capi_lib = b.addLibrary(.{
+            .name = "zolt_capi",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/c_api.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "zolt_pool", .module = zolt_pool_mod },
+                    .{ .name = "zolt_arith", .module = zolt_arith_mod },
+                },
+            }),
+        });
+        if (is_apple_silicon) linkMetalFrameworks(capi_lib.root_module);
+        b.installArtifact(capi_lib);
+
         // Main executable (for testing/demo)
         const exe = b.addExecutable(.{
             .name = "zolt",

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Zolt — Browser ZK Proof Demo</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body {
+    font-family: system-ui, -apple-system, sans-serif;
+    max-width: 640px; margin: 40px auto; padding: 0 20px;
+    color: #1a1a1a; background: #fafafa;
+  }
+  h1 { font-size: 1.4rem; margin-bottom: 4px; }
+  .subtitle { color: #666; margin-top: 0; }
+  #log {
+    background: #111; color: #0f0; font-family: monospace;
+    font-size: 13px; padding: 16px; border-radius: 8px;
+    min-height: 200px; max-height: 500px; overflow-y: auto;
+    white-space: pre-wrap; word-break: break-all;
+  }
+  button {
+    font-size: 1rem; padding: 10px 24px; margin: 12px 4px 12px 0;
+    border: none; border-radius: 6px; cursor: pointer;
+    background: #2563eb; color: #fff; font-weight: 600;
+  }
+  button:disabled { opacity: .4; cursor: not-allowed; }
+  button.secondary { background: #555; }
+  select {
+    font-size: 1rem; padding: 8px 12px; margin: 12px 4px 12px 0;
+    border: 1px solid #ccc; border-radius: 6px; background: #fff;
+  }
+  .drop-zone {
+    border: 2px dashed #aaa; border-radius: 8px; padding: 24px;
+    text-align: center; color: #888; margin: 12px 0;
+    transition: border-color .15s, background .15s;
+  }
+  .drop-zone.active { border-color: #2563eb; background: #eff6ff; }
+</style>
+</head>
+<body>
+
+<h1>Zolt WASM Prover</h1>
+<p class="subtitle">Generate a zero-knowledge proof entirely in the browser.</p>
+
+<button id="btn-load" disabled>Load WASM module</button>
+<select id="elf-select">
+  <option value="fibonacci.elf">fibonacci.elf (fast)</option>
+  <option value="sha256.elf">sha256.elf</option>
+  <option value="sha256_128.elf">sha256_128.elf</option>
+  <option value="sha256_512.elf">sha256_512.elf</option>
+  <option value="sha256_1024.elf">sha256_1024.elf</option>
+  <option value="sha256_2048.elf">sha256_2048.elf (slow)</option>
+  <option value="sha256_inline.elf">sha256_inline.elf</option>
+</select>
+<button id="btn-prove" disabled>Prove</button>
+<button id="btn-clear" class="secondary">Clear log</button>
+
+<div id="drop-zone" class="drop-zone">
+  Or drag &amp; drop any RISC-V ELF here
+</div>
+
+<div id="log"></div>
+
+<script type="module">
+const logEl = document.getElementById("log");
+const btnLoad = document.getElementById("btn-load");
+const btnProve = document.getElementById("btn-prove");
+const btnClear = document.getElementById("btn-clear");
+const dropZone = document.getElementById("drop-zone");
+const elfSelect = document.getElementById("elf-select");
+
+let elfBytes = null;
+let elfName = null;
+let proverWorker = null;
+let computeWorkers = [];
+let poolHandle = null;
+let isThreaded = false;
+let workerCount = 0;
+let wasmModule = null; // cached compiled module (reused across resets)
+
+function log(msg) {
+  logEl.textContent += msg + "\n";
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+// ---- Helpers ----
+
+function waitForMessage(worker, type) {
+  return new Promise((resolve, reject) => {
+    const handler = ({ data }) => {
+      if (data.type === type) { worker.removeEventListener("message", handler); resolve(data); }
+      if (data.type === "error") { worker.removeEventListener("message", handler); reject(new Error(data.message)); }
+    };
+    worker.addEventListener("message", handler);
+  });
+}
+
+function hasSharedArrayBuffer() {
+  try { new SharedArrayBuffer(1); return true; } catch { return false; }
+}
+
+// ---- Load WASM module ----
+
+async function loadWasm() {
+  btnLoad.disabled = true;
+  const t0 = performance.now();
+  const canThread = hasSharedArrayBuffer();
+
+  try {
+    let wasmBytes = null;
+    let label = "";
+
+    // Try threaded build first
+    if (canThread) {
+      try {
+        const resp = await fetch("/zig-out/wasm32-threaded/zolt_capi.wasm");
+        if (resp.ok) { wasmBytes = await resp.arrayBuffer(); isThreaded = true; label = "wasm32-threaded"; }
+      } catch { /* fall through */ }
+    }
+    if (!wasmBytes) {
+      isThreaded = false;
+      try {
+        const resp = await fetch("/zig-out/wasm64/zolt_capi.wasm");
+        if (resp.ok) { wasmBytes = await resp.arrayBuffer(); label = "wasm64"; }
+      } catch { /* fall through */ }
+    }
+    if (!wasmBytes) {
+      const resp = await fetch("/zig-out/wasm32/zolt_capi.wasm");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      wasmBytes = await resp.arrayBuffer();
+      label = "wasm32";
+    }
+
+    log(`Fetched ${label} binary: ${(wasmBytes.byteLength / 1024 / 1024).toFixed(1)} MB`);
+    wasmModule = await WebAssembly.compile(wasmBytes);
+
+    if (isThreaded) {
+      await setupThreaded();
+    } else {
+      await setupNonThreaded();
+    }
+    log(`Setup done in ${(performance.now() - t0).toFixed(0)} ms`);
+
+    btnProve.disabled = false;
+    await loadElf(elfSelect.value);
+  } catch (e) {
+    log(`ERROR: ${e.message}`);
+    btnLoad.disabled = false;
+  }
+}
+
+function teardownWorkers() {
+  for (const w of computeWorkers) w.terminate();
+  computeWorkers = [];
+  if (proverWorker) proverWorker.terminate();
+  proverWorker = null;
+  poolHandle = null;
+}
+
+async function setupThreaded() {
+  teardownWorkers();
+
+  const cores = navigator.hardwareConcurrency || 4;
+  workerCount = Math.min(cores - 1, 15);
+
+  // Fresh shared memory for each setup (avoids allocator fragmentation between proves)
+  const INITIAL_PAGES = 256 * 1024 * 1024 / 65536;
+  const MAX_PAGES = 4 * 1024 * 1024 * 1024 / 65536;
+  const memory = new WebAssembly.Memory({ initial: INITIAL_PAGES, maximum: MAX_PAGES, shared: true });
+
+  // Spawn prover + compute workers, let them all instantiate.
+  proverWorker = new Worker("zolt-prover.js");
+  proverWorker.addEventListener("message", ({ data }) => {
+    if (data.type === "status") log(data.message);
+    if (data.type === "error") log(`Prover error: ${data.message}`);
+  });
+  proverWorker.postMessage({ type: "init", wasmModule, memory });
+  await waitForMessage(proverWorker, "ready");
+
+  let computeReady = 0;
+  for (let i = 0; i < workerCount; i++) {
+    const w = new Worker("zolt-worker.js");
+    w.addEventListener("message", ({ data: msg }) => {
+      if (msg.type === "ready") computeReady++;
+      if (msg.type === "error") log(`Worker ${msg.workerId} error: ${msg.message}`);
+    });
+    w.postMessage({ type: "init", wasmModule, memory, workerId: i });
+    computeWorkers.push(w);
+  }
+  while (computeReady < workerCount) await new Promise(r => setTimeout(r, 50));
+
+  // Prover creates pool + allocates stacks/TLS.
+  proverWorker.postMessage({ type: "setup", workerCount });
+  const setup = await waitForMessage(proverWorker, "setup-done");
+  poolHandle = setup.poolHandle;
+
+  for (let i = 0; i < workerCount; i++) {
+    computeWorkers[i].postMessage({
+      type: "start",
+      poolPtr: setup.poolPtr,
+      workerId: i,
+      stackBase: setup.workerInfos[i].stackBase,
+      tlsBase: setup.workerInfos[i].tlsBase,
+    });
+  }
+  await new Promise(r => setTimeout(r, 100));
+  log(`${workerCount} workers active (${cores} cores)`);
+}
+
+async function setupNonThreaded() {
+  teardownWorkers();
+  proverWorker = new Worker("zolt-prover.js");
+  proverWorker.addEventListener("message", ({ data }) => {
+    if (data.type === "status") log(data.message);
+    if (data.type === "error") log(`Prover error: ${data.message}`);
+  });
+  proverWorker.postMessage({ type: "init", wasmModule, memory: null });
+  await waitForMessage(proverWorker, "ready");
+  poolHandle = 0;
+  log("Single-threaded mode");
+}
+
+// ---- Load ELF by name ----
+
+async function loadElf(name) {
+  try {
+    const resp = await fetch(`/examples/${name}`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    elfBytes = new Uint8Array(await resp.arrayBuffer());
+    elfName = name;
+    log(`\nLoaded ${name} (${elfBytes.length} bytes)`);
+  } catch (e) {
+    log(`Could not load ${name}: ${e.message}`);
+  }
+}
+
+// ---- Prove (non-blocking!) ----
+
+async function prove() {
+  if (!wasmModule || !elfBytes) return;
+  btnProve.disabled = true;
+
+  try {
+    // Fresh memory + workers for each prove (wasm_allocator isn't thread-safe,
+    // so we need a clean slate to avoid corruption from parallel allocations).
+    const t0 = performance.now();
+    if (isThreaded) await setupThreaded(); else await setupNonThreaded();
+    const setupMs = (performance.now() - t0).toFixed(0);
+    log(`\nWorkers ready (${setupMs} ms setup)`);
+  } catch (e) {
+    log(`\nSetup error: ${e.message}`);
+    btnProve.disabled = false;
+    return;
+  }
+
+  const modeLabel = isThreaded ? `${workerCount} workers` : "single-threaded";
+  log(`Proving ${elfName || "ELF"} (${modeLabel})...`);
+
+  // Send ELF to prover worker — main thread stays responsive!
+  proverWorker.postMessage({
+    type: "prove",
+    elfBytes,
+    elfName,
+    poolHandle: poolHandle || 0,
+  });
+
+  try {
+    const result = await waitForMessage(proverWorker, "proof-done");
+    log(`Proof generated in ${result.elapsed}s`);
+    log(`  size  : ${result.proofSize} bytes`);
+    log(`  memory: ${result.memMB} MB used`);
+    log(`  sha256: ${result.sha256}`);
+    log("\nDone!");
+  } catch (e) {
+    log(`ERROR: ${e.message}`);
+  } finally {
+    btnProve.disabled = false;
+  }
+}
+
+// ---- Drag & drop ----
+
+dropZone.addEventListener("dragover", e => { e.preventDefault(); dropZone.classList.add("active"); });
+dropZone.addEventListener("dragleave", () => dropZone.classList.remove("active"));
+dropZone.addEventListener("drop", async e => {
+  e.preventDefault();
+  dropZone.classList.remove("active");
+  const file = e.dataTransfer.files[0];
+  if (!file) return;
+  elfBytes = new Uint8Array(await file.arrayBuffer());
+  elfName = file.name;
+  log(`\nLoaded ${file.name} (${elfBytes.length} bytes) via drag & drop`);
+  if (proverWorker) btnProve.disabled = false;
+});
+
+// ---- Wire up ----
+
+btnLoad.addEventListener("click", loadWasm);
+btnProve.addEventListener("click", prove);
+btnClear.addEventListener("click", () => { logEl.textContent = ""; });
+elfSelect.addEventListener("change", () => { if (proverWorker) loadElf(elfSelect.value); });
+
+btnLoad.disabled = false;
+log("Click 'Load WASM module' to begin.");
+</script>
+</body>
+</html>

--- a/examples/browser/serve.sh
+++ b/examples/browser/serve.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# Build threaded wasm32 (with atomics + bulk_memory)
+echo "Building wasm32-threaded..."
+zig build -Dtarget=wasm32-freestanding -Dcpu=generic+atomics+bulk_memory -Doptimize=ReleaseFast
+mkdir -p zig-out/wasm32-threaded
+cp zig-out/bin/zolt_capi.wasm zig-out/wasm32-threaded/
+
+# Build plain wasm64 and wasm32 (single-threaded fallback)
+echo "Building wasm64..."
+zig build -Dtarget=wasm64-freestanding -Doptimize=ReleaseFast
+mkdir -p zig-out/wasm64
+cp zig-out/bin/zolt_capi.wasm zig-out/wasm64/
+
+echo "Building wasm32..."
+zig build -Dtarget=wasm32-freestanding -Doptimize=ReleaseFast
+mkdir -p zig-out/wasm32
+cp zig-out/bin/zolt_capi.wasm zig-out/wasm32/
+
+PORT="${1:-8080}"
+echo ""
+echo "Serving at http://localhost:$PORT/examples/browser/"
+echo "Press Ctrl-C to stop."
+
+# SharedArrayBuffer requires Cross-Origin-Opener-Policy and
+# Cross-Origin-Embedder-Policy headers. Use a custom Python handler.
+python3 - "$PORT" <<'PYEOF'
+import sys, http.server, functools
+
+class COOPCOEPHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        super().end_headers()
+
+port = int(sys.argv[1])
+server = http.server.HTTPServer(("", port), COOPCOEPHandler)
+server.serve_forever()
+PYEOF

--- a/examples/browser/zolt-prover.js
+++ b/examples/browser/zolt-prover.js
@@ -1,0 +1,102 @@
+// Zolt Prover Worker — runs all WASM operations off the main thread.
+// The main thread stays responsive while proving runs here.
+
+let zolt = null; // WASM instance exports
+
+self.onmessage = async ({ data }) => {
+  switch (data.type) {
+
+    case "init": {
+      // Instantiate WASM module (with shared memory if threaded, standalone if not).
+      const { wasmModule, memory } = data;
+      try {
+        const imports = memory ? { env: { memory } } : {};
+        const instance = await WebAssembly.instantiate(wasmModule, imports);
+        zolt = instance.exports;
+        self.postMessage({ type: "ready" });
+      } catch (e) {
+        self.postMessage({ type: "error", message: e.message });
+      }
+      break;
+    }
+
+    case "setup": {
+      // Create pool, allocate stacks + TLS for compute workers.
+      const { workerCount } = data;
+      try {
+        const poolHandle = zolt.zolt_thread_pool_create_wasm(workerCount);
+        if (!poolHandle) throw new Error("zolt_thread_pool_create_wasm returned null");
+        const poolPtr = zolt.zolt_thread_pool_ptr(poolHandle);
+
+        const tlsSize = zolt.__tls_size.value;
+        const tlsAlign = zolt.__tls_align.value;
+        const STACK_SIZE = 1 * 1024 * 1024; // 1 MB
+
+        const workerInfos = [];
+        for (let i = 0; i < workerCount; i++) {
+          const stackAlloc = zolt.zolt_alloc(STACK_SIZE);
+          if (!stackAlloc) throw new Error(`Failed to allocate stack for worker ${i}`);
+          const stackBase = stackAlloc + STACK_SIZE; // stacks grow downward
+
+          const tlsAlloc = zolt.zolt_alloc(tlsSize + tlsAlign);
+          if (!tlsAlloc) throw new Error(`Failed to allocate TLS for worker ${i}`);
+          const tlsBase = (tlsAlloc + tlsAlign - 1) & ~(tlsAlign - 1);
+
+          workerInfos.push({ stackBase, tlsBase });
+        }
+
+        self.postMessage({ type: "setup-done", poolPtr, workerInfos, poolHandle });
+      } catch (e) {
+        self.postMessage({ type: "error", message: e.message });
+      }
+      break;
+    }
+
+    case "prove": {
+      // Load ELF, run prover, return result.
+      const { elfBytes, elfName, poolHandle } = data;
+      try {
+        // Copy ELF into WASM memory
+        const elfPtr = zolt.zolt_alloc(elfBytes.length);
+        if (!elfPtr) throw new Error("zolt_alloc returned null");
+        const mem = new Uint8Array(zolt.memory.buffer);
+        mem.set(elfBytes, elfPtr);
+
+        // Load ELF with pool handle
+        const elfHandle = zolt.zolt_load_elf_bytes(poolHandle, elfPtr, elfBytes.length);
+        zolt.zolt_free(elfPtr, elfBytes.length);
+        if (!elfHandle) throw new Error("zolt_load_elf_bytes returned null");
+
+        const bytecodeSize = zolt.zolt_loaded_elf_size(elfHandle);
+        self.postMessage({ type: "status", message: `ELF loaded -- bytecode: ${bytecodeSize} bytes` });
+
+        // Prove
+        const t0 = performance.now();
+        const proofHandle = zolt.zolt_prove(elfHandle);
+        const elapsed = ((performance.now() - t0) / 1000).toFixed(2);
+        zolt.zolt_loaded_elf_destroy(elfHandle);
+
+        if (!proofHandle) throw new Error("zolt_prove returned null");
+
+        const proofSize = zolt.zolt_proof_result_size(proofHandle);
+        const proofPtr = zolt.zolt_proof_result_ptr(proofHandle);
+        const proofBytes = new Uint8Array(zolt.memory.buffer, proofPtr, proofSize).slice();
+        zolt.zolt_proof_result_destroy(proofHandle);
+
+        const memMB = (zolt.memory.buffer.byteLength / 1024 / 1024).toFixed(0);
+
+        // Hash the proof
+        const hash = await crypto.subtle.digest("SHA-256", proofBytes);
+        const sha256 = [...new Uint8Array(hash)].map(b => b.toString(16).padStart(2, "0")).join("");
+
+        self.postMessage({
+          type: "proof-done",
+          elapsed, proofSize, memMB, sha256,
+        });
+      } catch (e) {
+        self.postMessage({ type: "error", message: e.message });
+      }
+      break;
+    }
+  }
+};

--- a/examples/browser/zolt-worker.js
+++ b/examples/browser/zolt-worker.js
@@ -1,0 +1,37 @@
+// Zolt Web Worker — two-phase init for proper TLS separation.
+// Phase 1 (init): Instantiate WASM module over shared memory.
+// Phase 2 (start): Allocate TLS, set stack pointer, enter work-stealing loop.
+
+let wasmInstance = null;
+
+self.onmessage = async ({ data }) => {
+  if (data.type === "init") {
+    const { wasmModule, memory, workerId } = data;
+    try {
+      wasmInstance = await WebAssembly.instantiate(wasmModule, {
+        env: { memory },
+      });
+      self.postMessage({ type: "ready", workerId });
+    } catch (e) {
+      self.postMessage({ type: "error", workerId, message: e.message });
+    }
+
+  } else if (data.type === "start") {
+    const { poolPtr, workerId, stackBase, tlsBase } = data;
+    try {
+      // Set per-worker stack and TLS regions.
+      // Each instance has its own __stack_pointer and __tls_base globals,
+      // but they must point to separate regions in shared linear memory.
+      wasmInstance.exports.__stack_pointer.value = stackBase;
+
+      // Initialize TLS for this worker — copies initial TLS data to tlsBase
+      // and sets __tls_base to point there.
+      wasmInstance.exports.__wasm_init_tls(tlsBase);
+
+      wasmInstance.exports.zolt_worker_entry(poolPtr, workerId);
+      self.postMessage({ type: "exited", workerId });
+    } catch (e) {
+      self.postMessage({ type: "error", workerId, message: e.message });
+    }
+  }
+};

--- a/packages/zolt-pool/build.zig
+++ b/packages/zolt-pool/build.zig
@@ -4,11 +4,19 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // When targeting WASM with atomics, compile as multi-threaded so
+    // `threadlocal` uses proper per-instance TLS via __tls_base, instead
+    // of compiling to a fixed address in shared memory.
+    const is_wasm = target.result.cpu.arch == .wasm32 or target.result.cpu.arch == .wasm64;
+    const has_atomics = is_wasm and
+        std.Target.wasm.featureSetHas(target.result.cpu.features, .atomics);
+
     // Export the zolt_pool module
     _ = b.addModule("zolt_pool", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+        .single_threaded = if (has_atomics) false else null,
     });
 
     // Tests

--- a/packages/zolt-pool/src/root.zig
+++ b/packages/zolt-pool/src/root.zig
@@ -5,6 +5,7 @@
 pub const thread_pool = @import("thread_pool.zig");
 pub const ThreadPool = thread_pool.ThreadPool;
 pub const is_wasm = thread_pool.is_wasm;
+pub const has_wasm_atomics = thread_pool.has_wasm_atomics;
 
 pub const parallel_sort = @import("parallel_sort.zig");
 pub const parallelSort = parallel_sort.parallelSort;

--- a/packages/zolt-pool/src/thread_pool.zig
+++ b/packages/zolt-pool/src/thread_pool.zig
@@ -9,11 +9,69 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const atomic = std.atomic;
-const Futex = std.Thread.Futex;
 const Allocator = std.mem.Allocator;
 
 /// True when targeting WebAssembly (wasm32 or wasm64).
 pub const is_wasm = builtin.cpu.arch == .wasm32 or builtin.cpu.arch == .wasm64;
+
+/// True when targeting WASM with the `atomics` CPU feature enabled.
+/// Enables WasmWorkerPool (parallel proving via Web Workers + SharedArrayBuffer).
+pub const has_wasm_atomics = is_wasm and
+    std.Target.wasm.featureSetHas(builtin.cpu.features, .atomics);
+
+/// Platform-appropriate futex. On native: std.Thread.Futex.
+/// On WASM with atomics: direct memory.atomic.wait32/notify intrinsics,
+/// bypassing std.Thread.Futex which requires single_threaded=false
+/// (incompatible with std.heap.wasm_allocator).
+const Futex = if (has_wasm_atomics) WasmFutex else std.Thread.Futex;
+
+const WasmFutex = struct {
+    /// Block until woken. Uses memory.atomic.wait32.
+    fn wait(ptr: *const atomic.Value(u32), expect: u32) void {
+        const result = asm volatile (
+            \\local.get %[ptr]
+            \\local.get %[expected]
+            \\local.get %[timeout]
+            \\memory.atomic.wait32 0
+            \\local.set %[ret]
+            : [ret] "=r" (-> u32),
+            : [ptr] "r" (&ptr.raw),
+              [expected] "r" (@as(i32, @bitCast(expect))),
+              [timeout] "r" (@as(i64, -1)),
+        );
+        _ = result;
+    }
+
+    /// Block with timeout (nanoseconds). Uses memory.atomic.wait32.
+    fn timedWait(ptr: *const atomic.Value(u32), expect: u32, timeout_ns: u64) error{Timeout}!void {
+        const result = asm volatile (
+            \\local.get %[ptr]
+            \\local.get %[expected]
+            \\local.get %[timeout]
+            \\memory.atomic.wait32 0
+            \\local.set %[ret]
+            : [ret] "=r" (-> u32),
+            : [ptr] "r" (&ptr.raw),
+              [expected] "r" (@as(i32, @bitCast(expect))),
+              [timeout] "r" (@as(i64, @intCast(timeout_ns))),
+        );
+        if (result == 2) return error.Timeout;
+    }
+
+    /// Wake up to max_waiters threads. Uses memory.atomic.notify.
+    fn wake(ptr: *const atomic.Value(u32), max_waiters: u32) void {
+        if (max_waiters == 0) return;
+        _ = asm volatile (
+            \\local.get %[ptr]
+            \\local.get %[waiters]
+            \\memory.atomic.notify 0
+            \\local.set %[ret]
+            : [ret] "=r" (-> u32),
+            : [ptr] "r" (&ptr.raw),
+              [waiters] "r" (max_waiters),
+        );
+    }
+};
 
 /// Minimum number of elements per thread to justify parallelism.
 /// Below this threshold, work runs sequentially on the caller's thread.
@@ -29,6 +87,10 @@ const YIELD_ITERS: u32 = 8;
 // Chase-Lev deque capacity (power of 2). Supports ~256 pending jobs per worker.
 // Max depth with 3-level nesting and adaptive splitting: ~54 entries.
 const DEQUE_CAP: usize = 256;
+
+/// Deque index type. wasm32 atomics are limited to 32-bit operands.
+/// i32 wraps after ~2B operations — more than sufficient for browser proving sessions.
+const DequeIdx = if (builtin.cpu.arch == .wasm32) i32 else i64;
 
 const WorkerState = enum(u32) {
     spinning = 0,
@@ -159,7 +221,7 @@ const SpinLatch = struct {
                 if (self.probe()) return;
                 atomic.spinLoopHint();
             }
-            std.Thread.yield() catch {};
+            if (is_wasm) atomic.spinLoopHint() else std.Thread.yield() catch {};
         }
     }
 };
@@ -170,8 +232,8 @@ const SpinLatch = struct {
 
 const Deque = struct {
     buffer: [DEQUE_CAP]*Job align(cache_line) = undefined,
-    bottom: atomic.Value(i64) align(cache_line) = atomic.Value(i64).init(0),
-    top: atomic.Value(i64) align(cache_line) = atomic.Value(i64).init(0),
+    bottom: atomic.Value(DequeIdx) align(cache_line) = atomic.Value(DequeIdx).init(0),
+    top: atomic.Value(DequeIdx) align(cache_line) = atomic.Value(DequeIdx).init(0),
 
     const StealResult = union(enum) {
         success: *Job,
@@ -256,8 +318,9 @@ const WorkerData = struct {
     claim_depth: atomic.Value(u32) = atomic.Value(u32).init(0),
 
     fn initRng(self: *WorkerData) void {
-        // Seed RNG with index + timestamp for randomness
-        const ts: u64 = @truncate(@as(u128, @bitCast(std.time.nanoTimestamp())));
+        // Seed RNG with index + timestamp for randomness.
+        // On WASM there is no clock — index-based seed is fine for steal randomization.
+        const ts: u64 = if (is_wasm) 0 else @truncate(@as(u128, @bitCast(std.time.nanoTimestamp())));
         self.rng_state = @truncate((self.index +% 1) *% 2654435761 +% ts);
         if (self.rng_state == 0) self.rng_state = 1;
     }
@@ -351,7 +414,12 @@ comptime {
 // ThreadPool — conditional type: native work-stealing pool vs WASM sequential stub
 // ============================================================================
 
-pub const ThreadPool = if (is_wasm) WasmThreadPoolStub else NativeThreadPool;
+pub const ThreadPool = if (has_wasm_atomics)
+    WasmWorkerPool
+else if (is_wasm)
+    WasmThreadPoolStub
+else
+    NativeThreadPool;
 
 // ============================================================================
 // WASM Sequential Stub
@@ -466,6 +534,92 @@ const WasmThreadPoolStub = struct {
         _ = self;
         return .{ func_a(context_a), func_b(context_b) };
     }
+};
+
+// ============================================================================
+// WASM Worker Pool (parallel via Web Workers + SharedArrayBuffer)
+// ============================================================================
+
+/// Work-stealing thread pool for WASM with atomics. Same API as NativeThreadPool.
+/// Workers are Web Workers that call `workerEntry` from JS — no OS thread spawning.
+/// Each Web Worker instantiates its own WASM module, so module-level globals
+/// (including `threadlocal`) provide per-worker TLS for free.
+const WasmWorkerPool = struct {
+    workers: [MAX_THREADS + 1]WorkerData,
+    thread_count: usize,
+    allocator: Allocator,
+    generation: atomic.Value(u32) align(cache_line),
+
+    /// Initialize with zero workers. JS will set the count via initWithCount.
+    pub fn init(alloc: Allocator) !*ThreadPool {
+        return initWithCount(alloc, 0);
+    }
+
+    /// Initialize with a specific worker count. Does NOT spawn threads —
+    /// JS creates Web Workers that call workerEntry.
+    pub fn initWithCount(alloc: Allocator, thread_count: usize) !*ThreadPool {
+        const actual_count = @min(thread_count, MAX_THREADS);
+        const self = try alloc.create(ThreadPool);
+        self.* = .{
+            .workers = [_]WorkerData{.{}} ** (MAX_THREADS + 1),
+            .thread_count = actual_count,
+            .allocator = alloc,
+            .generation = atomic.Value(u32).init(0),
+        };
+        for (0..actual_count + 1) |i| {
+            self.workers[i].pool_ptr = self;
+            self.workers[i].index = i;
+            self.workers[i].initRng();
+        }
+        return self;
+    }
+
+    /// Signal shutdown and wake all workers. JS terminates Web Workers.
+    pub fn deinit(self: *ThreadPool) void {
+        for (self.workers[0..self.thread_count]) |*w| {
+            w.state.store(@intFromEnum(WorkerState.shutdown), .release);
+        }
+        _ = self.generation.fetchAdd(1, .release);
+        for (self.workers[0..self.thread_count]) |*w| {
+            Futex.wake(&w.state, 1);
+        }
+        if (tls_worker) |w| {
+            if (w.pool_ptr == self) {
+                w.claim_depth.store(0, .release);
+                tls_worker = null;
+            }
+        }
+        self.allocator.destroy(self);
+    }
+
+    /// Entry point for Web Workers. Called from JS via C API.
+    /// Blocking — enters the spin/steal/park loop, returns on shutdown.
+    pub fn workerEntry(self: *ThreadPool, worker_idx: usize) void {
+        NativeThreadPool.workerMain(self, worker_idx);
+    }
+
+    // All shared methods aliased from NativeThreadPool. When compiled,
+    // `*ThreadPool` resolves to `*WasmWorkerPool` — field layout matches.
+    pub const getCurrentWorker = NativeThreadPool.getCurrentWorker;
+    pub const getPool = NativeThreadPool.getPool;
+    pub const parallelFor = NativeThreadPool.parallelFor;
+    pub const parallelForForce = NativeThreadPool.parallelForForce;
+    pub const parallelForEach = NativeThreadPool.parallelForEach;
+    pub const parallelChunks = NativeThreadPool.parallelChunks;
+    pub const parallelReduce = NativeThreadPool.parallelReduce;
+    pub const parallelReduceForce = NativeThreadPool.parallelReduceForce;
+    pub const join = NativeThreadPool.join;
+
+    const releaseWorkerClaim = NativeThreadPool.releaseWorkerClaim;
+    const parallelForImpl = NativeThreadPool.parallelForImpl;
+    const parallelForImplWithThreshold = NativeThreadPool.parallelForImplWithThreshold;
+    const reduceImpl = NativeThreadPool.reduceImpl;
+    const rangeJobExecute = NativeThreadPool.rangeJobExecute;
+    const executeRange = NativeThreadPool.executeRange;
+    const joinJobExecute = NativeThreadPool.joinJobExecute;
+    const wakeWorkers = NativeThreadPool.wakeWorkers;
+    const effectiveThreads = NativeThreadPool.effectiveThreads;
+    const workerProcessWork = NativeThreadPool.workerProcessWork;
 };
 
 // ============================================================================
@@ -964,7 +1118,7 @@ const NativeThreadPool = struct {
                         if (latch.probe()) return;
                         atomic.spinLoopHint();
                     }
-                    std.Thread.yield() catch {};
+                    if (is_wasm) atomic.spinLoopHint() else std.Thread.yield() catch {};
                 }
             }
 
@@ -1203,7 +1357,7 @@ const NativeThreadPool = struct {
             // Phase 2: Yield (with stealing attempts)
             worker.state.store(@intFromEnum(WorkerState.yielding), .release);
             for (0..YIELD_ITERS) |_| {
-                std.Thread.yield() catch {};
+                if (is_wasm) atomic.spinLoopHint() else std.Thread.yield() catch {};
                 if (worker.state.load(.acquire) == @intFromEnum(WorkerState.shutdown)) return;
                 const g = self.generation.load(.acquire);
                 if (g != last_seen_gen) {
@@ -1261,7 +1415,7 @@ const NativeThreadPool = struct {
             if (consecutive_steal_failures <= 8) {
                 atomic.spinLoopHint();
             } else {
-                std.Thread.yield() catch {};
+                if (is_wasm) atomic.spinLoopHint() else std.Thread.yield() catch {};
             }
         }
     }

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 const zolt = @import("root.zig");
 const BN254Scalar = zolt.field.BN254Scalar;
 const is_wasm = @import("zolt_pool").is_wasm;
+const has_wasm_atomics = @import("zolt_pool").has_wasm_atomics;
 
 const allocator = if (is_wasm) std.heap.wasm_allocator else std.heap.page_allocator;
 
@@ -49,6 +50,41 @@ export fn zolt_thread_pool_destroy(handle: ?*anyopaque) callconv(.c) void {
     const ctx: *ThreadPoolCtx = cast(ThreadPoolCtx, handle) orelse return;
     ctx.tp.deinit();
     allocator.destroy(ctx);
+}
+
+// ── WASM worker pool (threaded WASM only) ────────────────────────────
+
+/// Create a thread pool with an explicit worker count (for WASM Web Workers).
+/// Returns null without atomics support or on allocation failure.
+export fn zolt_thread_pool_create_wasm(thread_count: u32) callconv(.c) ?*anyopaque {
+    if (comptime has_wasm_atomics) {
+        const tp = zolt.utils.ThreadPool.initWithCount(allocator, thread_count) catch return null;
+        const ctx = allocator.create(ThreadPoolCtx) catch {
+            tp.deinit();
+            return null;
+        };
+        ctx.* = .{ .tp = tp };
+        return @ptrCast(ctx);
+    }
+    return null;
+}
+
+/// Get the raw pool pointer as usize (passed to workers for zolt_worker_entry).
+export fn zolt_thread_pool_ptr(handle: ?*anyopaque) callconv(.c) usize {
+    if (comptime has_wasm_atomics) {
+        const ctx: *ThreadPoolCtx = cast(ThreadPoolCtx, handle) orelse return 0;
+        return @intFromPtr(ctx.tp);
+    }
+    return 0;
+}
+
+/// Worker entry point — blocking. Called by each Web Worker.
+/// Enters the spin/steal/park loop and returns on pool shutdown.
+export fn zolt_worker_entry(pool_ptr: usize, worker_id: u32) callconv(.c) void {
+    if (comptime has_wasm_atomics) {
+        const tp: *zolt.utils.ThreadPool = @ptrFromInt(pool_ptr);
+        tp.workerEntry(@intCast(worker_id));
+    }
 }
 
 // ── ELF loading (filesystem — native only) ───────────────────────────
@@ -173,6 +209,17 @@ export fn zolt_proof_result_destroy(handle: ?*anyopaque) callconv(.c) void {
     const result: *ProofResult = cast(ProofResult, handle) orelse return;
     allocator.free(result.bytes);
     allocator.destroy(result);
+}
+
+// ── WASM memory helpers ──────────────────────────────────────────────
+
+export fn zolt_alloc(len: usize) callconv(.c) ?[*]u8 {
+    const slice = allocator.alloc(u8, len) catch return null;
+    return slice.ptr;
+}
+
+export fn zolt_free(ptr: [*]u8, len: usize) callconv(.c) void {
+    allocator.free(ptr[0..len]);
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Add WasmWorkerPool backed by Web Workers + SharedArrayBuffer, enabling multi-threaded proving in the browser using the same Chase-Lev work-stealing pool as native.

Key changes:
- WasmWorkerPool: aliases NativeThreadPool methods, adds workerEntry() for JS-spawned workers. Three-way ThreadPool selection: WasmWorkerPool (atomics) / WasmThreadPoolStub (no atomics) / NativeThreadPool (native)
- WasmFutex: direct memory.atomic.wait32/notify intrinsics bypassing std.Thread.Futex (which requires single_threaded=false, incompatible with std.heap.wasm_allocator)
- DequeIdx: i32 on wasm32 (atomics limited to 32-bit operands)
- Build: shared_memory + import_memory flags, TLS exports (__tls_base/__tls_size/__wasm_init_tls) for per-worker TLS
- zolt_pool single_threaded=false for atomics builds so threadlocal uses __tls_base (not a fixed shared address)
- C API: zolt_thread_pool_create_wasm, zolt_thread_pool_ptr, zolt_worker_entry
- Browser demo: prover worker (non-blocking UI), compute workers, two-phase init, COOP/COEP headers for SharedArrayBuffer

Build: zig build -Dtarget=wasm32-freestanding \
  -Dcpu=generic+atomics+bulk_memory -Doptimize=ReleaseFast