### PR TITLE
perf: Stage 6 sumcheck micro-optimizations

### DIFF
--- a/src/zkvm/spartan/ra_poly.zig
+++ b/src/zkvm/spartan/ra_poly.zig
@@ -33,8 +33,11 @@ pub fn RaPolynomial(comptime F: type) type {
             indices: []?u8,
             /// Small eq table (k_chunk entries, typically 16). Prescaled by `scale`. Owned.
             eq_table: []F,
+            /// True if any index is null; enables branchless fast path when false.
+            has_nulls: bool,
 
             pub inline fn getBoundCoeff(self: @This(), j: usize) F {
+                if (!self.has_nulls) return self.eq_table[self.indices[j].?];
                 return if (self.indices[j]) |idx|
                     self.eq_table[idx]
                 else
@@ -53,8 +56,13 @@ pub fn RaPolynomial(comptime F: type) type {
             /// F_0[k] = (1-r0)*eq[k], F_1[k] = r0*eq[k]. Owned.
             F_0: []F,
             F_1: []F,
+            /// Propagated from Round1; enables branchless fast path.
+            has_nulls: bool,
 
             pub inline fn getBoundCoeff(self: @This(), j: usize) F {
+                if (!self.has_nulls) {
+                    return self.F_0[self.indices[2 * j].?].add(self.F_1[self.indices[2 * j + 1].?]);
+                }
                 const v0 = if (self.indices[2 * j]) |idx| self.F_0[idx] else F.zero();
                 const v1 = if (self.indices[2 * j + 1]) |idx| self.F_1[idx] else F.zero();
                 return v0.add(v1);
@@ -74,12 +82,20 @@ pub fn RaPolynomial(comptime F: type) type {
             F_01: []F,
             F_10: []F,
             F_11: []F,
+            /// Propagated from Round1; enables branchless fast path.
+            has_nulls: bool,
 
             /// LE bit ordering: position offset g has bits [b1, b0] where
             /// b0 = round0 selector (F_?0 vs F_?1), b1 = round1 selector (F_0? vs F_1?).
             /// So: base+0 → F_00, base+1 → F_10, base+2 → F_01, base+3 → F_11.
             pub inline fn getBoundCoeff(self: @This(), j: usize) F {
                 const base = 4 * j;
+                if (!self.has_nulls) {
+                    return self.F_00[self.indices[base].?]
+                        .add(self.F_10[self.indices[base + 1].?])
+                        .add(self.F_01[self.indices[base + 2].?])
+                        .add(self.F_11[self.indices[base + 3].?]);
+                }
                 const v00 = if (self.indices[base]) |idx| self.F_00[idx] else F.zero();
                 const v10 = if (self.indices[base + 1]) |idx| self.F_10[idx] else F.zero();
                 const v01 = if (self.indices[base + 2]) |idx| self.F_01[idx] else F.zero();
@@ -124,9 +140,18 @@ pub fn RaPolynomial(comptime F: type) type {
             for (eq_table) |*entry| {
                 entry.* = entry.*.mul(scale);
             }
+            // Scan for null indices to enable branchless fast paths in getBoundCoeff
+            var has_nulls = false;
+            for (indices) |idx| {
+                if (idx == null) {
+                    has_nulls = true;
+                    break;
+                }
+            }
             return .{ .round1 = .{
                 .indices = indices,
                 .eq_table = eq_table,
+                .has_nulls = has_nulls,
             } };
         }
 
@@ -176,11 +201,15 @@ pub fn RaPolynomial(comptime F: type) type {
                     // Free eq_table (replaced by F_0, F_1)
                     allocator.free(s.eq_table);
 
+                    // Capture has_nulls before overwriting the union payload
+                    const has_nulls = s.has_nulls;
+
                     // indices pointer is shared into round2 (NOT freed)
                     self.* = .{ .round2 = .{
                         .indices = s.indices,
                         .F_0 = F_0,
                         .F_1 = F_1,
+                        .has_nulls = has_nulls,
                     } };
                 },
                 .round2 => |*s| {
@@ -208,12 +237,16 @@ pub fn RaPolynomial(comptime F: type) type {
                     allocator.free(s.F_0);
                     allocator.free(s.F_1);
 
+                    // Capture has_nulls before overwriting the union payload
+                    const has_nulls = s.has_nulls;
+
                     self.* = .{ .round3 = .{
                         .indices = s.indices,
                         .F_00 = F_00,
                         .F_01 = F_01,
                         .F_10 = F_10,
                         .F_11 = F_11,
+                        .has_nulls = has_nulls,
                     } };
                 },
                 .round3 => |*s| {

--- a/src/zkvm/spartan/stage6_instances.zig
+++ b/src/zkvm/spartan/stage6_instances.zig
@@ -1139,6 +1139,14 @@ pub fn RamRaVirtualProver(comptime F: type) type {
             const UPA = UnreducedProductAccum;
             const mapFn = struct {
                 fn f(c: Ctx, start: usize, end: usize) [MAX_RA_EVALS]F {
+                    // Dispatch once on ra_poly state to avoid per-access tag checks.
+                    // All ra_polys are in the same state at any given round.
+                    return switch (c.ra_polys[0]) {
+                        inline else => |_, comptime_tag| fInner(c, start, end, comptime_tag),
+                    };
+                }
+
+                inline fn fInner(c: Ctx, start: usize, end: usize, comptime tag: anytype) [MAX_RA_EVALS]F {
                     const MAX_D = 8;
                     var outer_acc: [MAX_RA_EVALS]UPA = .{UPA.zero()} ** MAX_RA_EVALS;
                     var inner_acc: [MAX_RA_EVALS]UPA = .{UPA.zero()} ** MAX_RA_EVALS;
@@ -1165,8 +1173,8 @@ pub fn RamRaVirtualProver(comptime F: type) type {
                         var lo: [MAX_D]F = undefined;
                         var delta: [MAX_D]F = undefined;
                         for (0..c.d) |i| {
-                            lo[i] = c.ra_polys[i].getBoundCoeff(2 * j);
-                            delta[i] = c.ra_polys[i].getBoundCoeff(2 * j + 1).sub(lo[i]);
+                            lo[i] = @field(c.ra_polys[i], @tagName(tag)).getBoundCoeff(2 * j);
+                            delta[i] = @field(c.ra_polys[i], @tagName(tag)).getBoundCoeff(2 * j + 1).sub(lo[i]);
                         }
 
                         var cur: [MAX_D]F = undefined;
@@ -2538,6 +2546,14 @@ pub fn LookupsRaVirtualProver(comptime F: type) type {
             const UPA = UnreducedProductAccum;
             const mapFn = struct {
                 fn f(c: Ctx, start: usize, end: usize) [4]F {
+                    // Dispatch once on ra_poly state to avoid per-access tag checks.
+                    // All ra_polys are in the same state at any given round.
+                    return switch (c.ra_polys[0]) {
+                        inline else => |_, comptime_tag| fInner(c, start, end, comptime_tag),
+                    };
+                }
+
+                inline fn fInner(c: Ctx, start: usize, end: usize, comptime tag: anytype) [4]F {
                     var outer_acc: [4]UPA = .{UPA.zero()} ** 4;
                     var inner_acc: [4]UPA = .{UPA.zero()} ** 4;
                     var prev_x_out: usize = if (start > 0) start >> @intCast(c.head_in_bits) else 0;
@@ -2567,8 +2583,8 @@ pub fn LookupsRaVirtualProver(comptime F: type) type {
                             for (0..c.M) |m_idx| {
                                 const idx = v * c.M + m_idx;
                                 pairs[m_idx] = .{
-                                    c.ra_polys[idx].getBoundCoeff(2 * j),
-                                    c.ra_polys[idx].getBoundCoeff(2 * j + 1),
+                                    @field(c.ra_polys[idx], @tagName(tag)).getBoundCoeff(2 * j),
+                                    @field(c.ra_polys[idx], @tagName(tag)).getBoundCoeff(2 * j + 1),
                                 };
                             }
                             const prod_evals = evalLinearProd4(F, pairs);


### PR DESCRIPTION
## Summary

- **Lift RaPolynomial tag dispatch out of inner loops**: Both `RamRaVirtualProver` and `LookupsRaVirtualProver` mapFn bodies now dispatch on the first ra_poly's active tag once via `inline else`, generating specialized loop bodies per variant. Inner loops use `@field(..., @tagName(tag)).getBoundCoeff()` instead of the tagged union's switch-based dispatch, eliminating per-access tag checks in release mode.
- **Add `has_nulls` branchless fast path**: `RaPolynomial` compressed rounds (Round1/2/3) now track a `has_nulls: bool` flag, computed during `initRound1` and propagated through bind transitions. When false (common for instruction lookups), `getBoundCoeff` skips optional index checks entirely.

Context: flamegraph analysis of sha256_2048 showed Stage 6 at 7.2% of total prover time. These are diminishing-returns micro-optimizations — the implementation already closely matches Jolt's approach.

## Benchmark (sha256_2048, 10 runs, ReleaseFast, Apple Silicon)

| Metric | Before (ms) | After (ms) | Delta | Change |
|--------|------------|------------|-------|--------|
| Mean   | 2814       | 2672       | -142  | **-5.1%** |
| Median | 2759       | 2651       | -108  | **-3.9%** |
| P25    | 2690       | 2607       | -83   | **-3.1%** |
| Min    | 2582       | 2540       | -43   | **-1.6%** |
| Stdev  | 188        | 105        |       |        |

Improvement is larger than the conservative 0.5–1% estimate — the `inline else` dispatch likely enables LLVM to further optimize the inner loops (inlining, register allocation) once the variant is statically known. Reduced stdev (188→105) suggests fewer branch mispredictions.

## Test plan

- [x] `zig build test` — all 539 tests pass
- [x] `zig build -Doptimize=ReleaseFast` — clean build
- [x] Before/after benchmark on sha256_2048 (10 runs each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)